### PR TITLE
Support log4j2 2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a collection of support libraries for Java applications running on Cloud
 
 When we say structured, we actually mean in JSON format. In that sense, it shares ideas with [logstash-logback-encoder](https://github.com/logstash/logstash-logback-encoder) (and a first internal version was actually based on it), but takes a simpler approach as we want to ensure that these structured messages adhere to standardized formats. With such standardized formats in place, it becomes much easier to ingest, process and search such messages in log analysis stacks like, e.g., [ELK](https://www.elastic.co/webinars/introduction-elk-stack).
 
-If you're interested in the specifications of these standardized formats, you may want to have closer look at the `fields.ml` files in the [beats folder](./cf-java-logging-support-core/beats).
+If you're interested in the specifications of these standardized formats, you may want to have closer look at the `fields.yml` files in the [beats folder](./cf-java-logging-support-core/beats).
 
 While [logstash-logback-encoder](https://github.com/logstash/logstash-logback-encoder) is tied to [logback](http://logback.qos.ch/), we've tried to stay implementation neutral and have implemented the core functionality on top of [slf4j](http://www.slf4j.org/),  but provide implementations for both [logback](http://logback.qos.ch/) and [log4j2](http://logging.apache.org/log4j/2.x/) (and we're open to contributions that would support other implementations).
 

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ The instrumentation part is currently focusing on providing [request filters for
 
 ## Features and dependencies
 
-As you can see from the structure of this repository, we're not providing one *uber* JAR that contains everything, but provide each feature separately. We also try to stay away from wiring up too many dependencies by tagging almost all of them as *provided.* As a consequence, it's your task to get all runtime dependencies resolved in your application POM file. 
+As you can see from the structure of this repository, we're not providing one *uber* JAR that contains everything, but provide each feature separately. We also try to stay away from wiring up too many dependencies by tagging almost all of them as *provided.* As a consequence, it's your task to get all runtime dependencies resolved in your application POM file.
 
 All in all, you should do the following:
 
-* make up your mind which features you actually need, 
-* adjust your Maven dependencies accordingly, 
+* make up your mind which features you actually need,
+* adjust your Maven dependencies accordingly,
 * pick your favorite logging implementation, and
 * adjust your logging configuration accordingly.
 
@@ -39,7 +39,7 @@ This feature only depends on the servlet API which you have included in your POM
 
 The *core* feature (on which all other features rely) is just using the `org.slf4j` API, but to actually get logs written, you need to pick an implementation feature. As stated above, we have two implementations
 
-* `cf-java-logging-support-logback` based on [logback](http://logback.qos.ch/), and 
+* `cf-java-logging-support-logback` based on [logback](http://logback.qos.ch/), and
 * `cf-java-logging-support-log4j2` based on [log4j2](http://logging.apache.org/log4j/2.x/).
 
 Again, we don't include dependencies to those implementation backends ourselves, so you need to provide the corresponding dependencies in your POM file:
@@ -91,7 +91,7 @@ Here are sort of the minimal configurations you'd need:
 	<appender name="STDOUT-JSON" class="ch.qos.logback.core.ConsoleAppender">
        <encoder class="com.sap.hcp.cf.logback.encoder.JsonEncoder"/>
     </appender>
-  	<!-- for local development, you may want to switch to a more human-readable layout --> 
+    <!-- for local development, you may want to switch to a more human-readable layout -->
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%date %-5level [%thread] - [%logger] [%mdc] - %msg%n</pattern>
@@ -102,14 +102,14 @@ Here are sort of the minimal configurations you'd need:
        <appender-ref ref="STDOUT-JSON" />
     </root>
   	<!-- request metrics are reported using INFO level, so make sure the instrumentation loggers are set to that level -->
-    <logger name="com.sap.hcp.cf" level="INFO" />	
+    <logger name="com.sap.hcp.cf" level="INFO" />
 </configuration>
 ```
 
 *log4j2.xml:*
 
 ``` xml
-<Configuration 
+<Configuration
    status="warn" strict="true"
    packages="com.sap.hcp.cf.log4j2.converter,com.sap.hcp.cf.log4j2.layout">
 	<Appenders>
@@ -128,7 +128,7 @@ Here are sort of the minimal configurations you'd need:
   	 <!-- request metrics are reported using INFO level, so make sure the instrumentation loggers are set to that level -->
      <Logger name="com.sap.hcp.cf" level="INFO"/>
   </Loggers>
-</Configuration>      
+</Configuration>
 ```
 
 ## Sample Application

--- a/cf-java-logging-support-core/pom.xml
+++ b/cf-java-logging-support-core/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>com.sap.hcp.cf.logging</groupId>
     <artifactId>cf-java-logging-support-parent</artifactId>
-    <version>2.0.9</version>
+    <version>2.0.10</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <profiles>

--- a/cf-java-logging-support-jersey/pom.xml
+++ b/cf-java-logging-support-jersey/pom.xml
@@ -9,7 +9,7 @@
   	<relativePath>../pom.xml</relativePath>
   	<groupId>com.sap.hcp.cf.logging</groupId>
   	<artifactId>cf-java-logging-support-parent</artifactId>
-  	<version>2.0.9</version>
+  	<version>2.0.10</version>
   </parent>
 
   <name>cf-java-logging-support-jersey</name>

--- a/cf-java-logging-support-log4j2/pom.xml
+++ b/cf-java-logging-support-log4j2/pom.xml
@@ -15,7 +15,7 @@
 	</parent>
 
 	<properties>
-		<log4j2.version>2.4.1</log4j2.version>
+		<log4j2.version>2.7</log4j2.version>
 	</properties>
 
 	<dependencies>

--- a/cf-java-logging-support-log4j2/pom.xml
+++ b/cf-java-logging-support-log4j2/pom.xml
@@ -11,7 +11,7 @@
 		<relativePath>../pom.xml</relativePath>
 		<groupId>com.sap.hcp.cf.logging</groupId>
 		<artifactId>cf-java-logging-support-parent</artifactId>
-		<version>2.0.9</version>
+		<version>2.0.10</version>
 	</parent>
 
 	<properties>

--- a/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/logging/common/AbstractTest.java
+++ b/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/logging/common/AbstractTest.java
@@ -20,16 +20,21 @@ public abstract class AbstractTest {
 
     protected final ByteArrayOutputStream outContent  = new ByteArrayOutputStream();
     protected final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+    private PrintStream stdout;
+    private PrintStream stderr;
+
 	@Before
 	public void setupStreams() {
+		stdout = System.out;
+		stderr = System.err;
 		System.setOut(new PrintStream(outContent));
 		System.setErr(new PrintStream(errContent));
 	}
 	
 	@After
 	public void teardownStreams() {
-        System.setOut(null);
-        System.setErr(null);		
+        System.setOut(stdout);
+        System.setErr(stderr);
 	}
 	protected String getMessage() {
 		return getField("msg");

--- a/cf-java-logging-support-logback/pom.xml
+++ b/cf-java-logging-support-logback/pom.xml
@@ -10,7 +10,7 @@
   	<relativePath>../pom.xml</relativePath>
   	<groupId>com.sap.hcp.cf.logging</groupId>
   	<artifactId>cf-java-logging-support-parent</artifactId>
-  	<version>2.0.9</version>
+  	<version>2.0.10</version>
   </parent>
 
   <properties>

--- a/cf-java-logging-support-servlet/pom.xml
+++ b/cf-java-logging-support-servlet/pom.xml
@@ -9,7 +9,7 @@
   <parent>
   	<groupId>com.sap.hcp.cf.logging</groupId>
   	<artifactId>cf-java-logging-support-parent</artifactId>
-  	<version>2.0.9</version>
+  	<version>2.0.10</version>
   	<relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.sap.hcp.cf.logging</groupId>
   <artifactId>cf-java-logging-support-parent</artifactId>
-  <version>2.0.9</version>
+  <version>2.0.10</version>
   <packaging>pom</packaging>
 
   <name>Cloud Foundry Java logging support components</name>

--- a/sample/manifest.yml
+++ b/sample/manifest.yml
@@ -7,4 +7,4 @@ applications:
   host: logging-sample-app
   instances: 1
   memory: 256M
-  path: target/logging-sample-app-2.0.9.war
+  path: target/logging-sample-app-2.0.10.war

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -12,7 +12,7 @@
 
 	<properties>
 		<tomcat.version>7.0.65</tomcat.version>
-		<log4j2.version>2.4.1</log4j2.version>
+		<log4j2.version>2.7</log4j2.version>
 		<logback.version>1.1.3</logback.version>
 		<jackson.version>2.5.4</jackson.version>
 		<slf4j.version>1.7.12</slf4j.version>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -18,6 +18,7 @@
 		<slf4j.version>1.7.12</slf4j.version>
 		<jersey.version>2.22.2</jersey.version>
 		<javax.ws.version>2.0.1</javax.ws.version>
+		<cf-logging.version>2.0.9</cf-logging.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -78,10 +79,10 @@
 
 <!-- LOG4J2 VERSION
 
- 		<dependency>
-  		<groupId>com.sap.hcp.cf-logging.logging</groupId>
-  		<artifactId>java-logging-support-log4j2</artifactId>
-  		<version>${cf-logging.version}</version>
+		<dependency>
+			<groupId>com.sap.hcp.cf.logging</groupId>
+			<artifactId>cf-java-logging-support-log4j2</artifactId>
+			<version>${cf-logging.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.sap.hcp.cf.logging</groupId>
 		<artifactId>cf-java-logging-support-parent</artifactId>
-		<version>2.0.9</version>
+		<version>2.0.10</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -18,7 +18,7 @@
 		<slf4j.version>1.7.12</slf4j.version>
 		<jersey.version>2.22.2</jersey.version>
 		<javax.ws.version>2.0.1</javax.ws.version>
-		<cf-logging.version>2.0.9</cf-logging.version>
+		<cf-logging.version>2.0.10</cf-logging.version>
 	</properties>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
Version 2.0.9 was not compatible with Log4j2 2.7

`
java.lang.IncompatibleClassChangeError: Expecting non-static method com.sap.hcp.cf.log4j2.layout.JsonPatternLayout.getStringBuilder()Ljava/lang/StringBuilder;
        com.sap.hcp.cf.log4j2.layout.JsonPatternLayout.toSerializable(JsonPatternLayout.java:41)
        com.sap.hcp.cf.log4j2.layout.JsonPatternLayout.toSerializable(JsonPatternLayout.java:21)
        org.apache.logging.log4j.core.layout.AbstractStringLayout.toByteArray(AbstractStringLayout.java:258)
`