### PR TITLE
Upgrade Jackson and JWT version

### DIFF
--- a/cf-java-logging-support-servlet/pom.xml
+++ b/cf-java-logging-support-servlet/pom.xml
@@ -47,18 +47,7 @@
         <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
-            <version>3.7.0</version>
-            <exclusions>
-            	<exclusion>
-            		<groupId>com.fasterxml.jackson.core</groupId>
-  					<artifactId>jackson-databind</artifactId>
-            	</exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-    		<version>${jackson-jr.version}</version>
-		</dependency>
-    </dependencies>
+            <version>3.8.1</version>
+         </dependency>
+     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jackson-jr.version>2.9.8</jackson-jr.version>
+        <jackson-jr.version>2.9.9</jackson-jr.version>
         <slf4j.version>1.7.25</slf4j.version>
         <logback.version>1.2.3</logback.version>
         <log4j2.version>2.8.2</log4j2.version>


### PR DESCRIPTION
java-jwt 3.8.1 has jackson 2.9.9 as dependency, so the exclusion is no longer needed