### PR TITLE
Fix correlation-id in cf-java-logging-support-servlet

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ All in all, you should do the following:
 And
 4. Adjust your logging configuration accordingly.
 
-Let's say you want to make use of the *servlet filter* feature, then you need to add the following dependency to your POM with property `cf-logging-version` referring to the latest nexus version (currently `3.0.2`):
+Let's say you want to make use of the *servlet filter* feature, then you need to add the following dependency to your POM with property `cf-logging-version` referring to the latest nexus version (currently `3.0.3`):
 
 ```xml
 <properties>
-	<cf-logging-version>3.0.2</cf-logging-version>
+	<cf-logging-version>3.0.3</cf-logging-version>
 </properties>
 ```
 

--- a/cf-java-logging-support-core/pom.xml
+++ b/cf-java-logging-support-core/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>com.sap.hcp.cf.logging</groupId>
         <artifactId>cf-java-logging-support-parent</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <build>

--- a/cf-java-logging-support-core/src/test/java/com/sap/hcp/cf/logging/common/converter/DefaultStacktraceConverterTest.java
+++ b/cf-java-logging-support-core/src/test/java/com/sap/hcp/cf/logging/common/converter/DefaultStacktraceConverterTest.java
@@ -81,7 +81,7 @@ public class DefaultStacktraceConverterTest extends AbstractConverterTest {
                          "\"\\tat com.sap.hcp.cf.logging.common.helper.StacktraceGenerator.f1IsASimpleFunctionWithAnExceptionallyLongName(StacktraceGenerator.java:X)\"," + //
                          "\"\\tat com.sap.hcp.cf.logging.common.helper.StacktraceGenerator.generateException(StacktraceGenerator.java:X)\"," + //
                          "\"\\tat com.sap.hcp.cf.logging.common.converter.DefaultStacktraceConverterTest$X.run(DefaultStacktraceConverterTest.java:X)\"," + //
-                         "\"\\tat java.lang.Thread.run(Thread.java:X)\"]";
+				"\"\\tat " + getThreadClassName() + ".run(Thread.java:X)\"]";
         Assert.assertEquals(expectedString, stringBuilder.toString().replaceAll(":\\d+\\)", ":X)").//
                                                          replaceAll("\\$\\d", "\\$X"));
     }
@@ -99,7 +99,7 @@ public class DefaultStacktraceConverterTest extends AbstractConverterTest {
         });
         thread.start();
         thread.join();
-        expectedString = "[\"-------- STACK TRACE TRUNCATED --------\"," + //
+		expectedString = "[\"-------- STACK TRACE TRUNCATED --------\"," + //
                          "\"java.lang.IllegalArgumentException: too long\"," + //
                          "\"\\tat com.sap.hcp.cf.logging.common.helper.StacktraceGenerator.f3IsASimpleFunctionWithAnExceptionallyLongName(StacktraceGenerator.java:X)\"," + //
                          "\"\\tat com.sap.hcp.cf.logging.common.helper.StacktraceGenerator.f3IsASimpleFunctionWithAnExceptionallyLongName(StacktraceGenerator.java:X)\"," + //
@@ -115,9 +115,17 @@ public class DefaultStacktraceConverterTest extends AbstractConverterTest {
                          "\"\\tat com.sap.hcp.cf.logging.common.helper.StacktraceGenerator.f1IsASimpleFunctionWithAnExceptionallyLongName(StacktraceGenerator.java:X)\"," + //
                          "\"\\tat com.sap.hcp.cf.logging.common.helper.StacktraceGenerator.generateException(StacktraceGenerator.java:X)\"," + //
                          "\"\\tat com.sap.hcp.cf.logging.common.converter.DefaultStacktraceConverterTest$X.run(DefaultStacktraceConverterTest.java:X)\"," + //
-                         "\"\\tat java.lang.Thread.run(Thread.java:X)\"]";
+				"\"\\tat " + getThreadClassName() + ".run(Thread.java:X)\"]";
         Assert.assertEquals(expectedString, stringBuilder.toString().replaceAll(":\\d+\\)", ":X)").//
                                                          replaceAll("\\$\\d", "\\$X"));
     }
+
+	// This method is required to account for the module path in stacktraces
+	// after Java 9
+	private String getThreadClassName() {
+		String stackTraceElement = Thread.currentThread().getStackTrace()[0].toString();
+		int i = stackTraceElement.indexOf("Thread");
+		return stackTraceElement.subSequence(0, i) + Thread.class.getSimpleName();
+	}
 
 }

--- a/cf-java-logging-support-jersey/pom.xml
+++ b/cf-java-logging-support-jersey/pom.xml
@@ -9,7 +9,7 @@
 		<relativePath>../pom.xml</relativePath>
 		<groupId>com.sap.hcp.cf.logging</groupId>
 		<artifactId>cf-java-logging-support-parent</artifactId>
-		<version>3.0.2</version>
+		<version>3.0.3</version>
 	</parent>
 
 	<name>cf-java-logging-support-jersey</name>

--- a/cf-java-logging-support-jersey/pom.xml
+++ b/cf-java-logging-support-jersey/pom.xml
@@ -57,6 +57,24 @@
 		</dependency>
 
 		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.2.8</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.sun.xml.bind</groupId>
+			<artifactId>jaxb-core</artifactId>
+			<version>2.2.11</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.sun.xml.bind</groupId>
+			<artifactId>jaxb-impl</artifactId>
+			<version>2.2.11</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>javax.activation</groupId>
 			<artifactId>activation</artifactId>
 			<version>1.1.1</version>

--- a/cf-java-logging-support-jersey/pom.xml
+++ b/cf-java-logging-support-jersey/pom.xml
@@ -1,78 +1,85 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
-    <artifactId>cf-java-logging-support-jersey</artifactId>
-    <packaging>jar</packaging>
+	<artifactId>cf-java-logging-support-jersey</artifactId>
+	<packaging>jar</packaging>
 
-    <parent>
-        <relativePath>../pom.xml</relativePath>
-        <groupId>com.sap.hcp.cf.logging</groupId>
-        <artifactId>cf-java-logging-support-parent</artifactId>
-        <version>3.0.2</version>
-    </parent>
+	<parent>
+		<relativePath>../pom.xml</relativePath>
+		<groupId>com.sap.hcp.cf.logging</groupId>
+		<artifactId>cf-java-logging-support-parent</artifactId>
+		<version>3.0.2</version>
+	</parent>
 
-    <name>cf-java-logging-support-jersey</name>
+	<name>cf-java-logging-support-jersey</name>
 
-    <properties>
-        <jersey.version>2.22.1</jersey.version>
-    </properties>
+	<properties>
+		<jersey.version>2.22.1</jersey.version>
+	</properties>
 
-    <dependencies>
-        <!-- Jersey - RESTful Web service -->
-        <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-client</artifactId>
-            <version>${jersey.version}</version>
-            <scope>provided</scope>
-        </dependency>
+	<dependencies>
+		<!-- Jersey - RESTful Web service -->
+		<dependency>
+			<groupId>org.glassfish.jersey.core</groupId>
+			<artifactId>jersey-client</artifactId>
+			<version>${jersey.version}</version>
+			<scope>provided</scope>
+		</dependency>
 
-        <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-server</artifactId>
-            <version>${jersey.version}</version>
-            <scope>provided</scope>
-        </dependency>
+		<dependency>
+			<groupId>org.glassfish.jersey.core</groupId>
+			<artifactId>jersey-server</artifactId>
+			<version>${jersey.version}</version>
+			<scope>provided</scope>
+		</dependency>
 
-        <dependency>
-            <groupId>com.sap.hcp.cf.logging</groupId>
-            <artifactId>cf-java-logging-support-core</artifactId>
-            <version>${project.version}</version>
-            <scope>compile</scope>
-        </dependency>
+		<dependency>
+			<groupId>com.sap.hcp.cf.logging</groupId>
+			<artifactId>cf-java-logging-support-core</artifactId>
+			<version>${project.version}</version>
+			<scope>compile</scope>
+		</dependency>
 
-        <!-- unit test related -->
-        <dependency>
-            <groupId>org.glassfish.jersey.test-framework</groupId>
-            <artifactId>jersey-test-framework-core</artifactId>
-            <version>${jersey.version}</version>
-            <scope>test</scope>
-        </dependency>
+		<!-- unit test related -->
+		<dependency>
+			<groupId>org.glassfish.jersey.test-framework</groupId>
+			<artifactId>jersey-test-framework-core</artifactId>
+			<version>${jersey.version}</version>
+			<scope>test</scope>
+		</dependency>
 
-        <dependency>
-            <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-            <artifactId>jersey-test-framework-provider-grizzly2</artifactId>
-            <version>${jersey.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <!-- we need our log4j2 implementation for testing! -->
-        <dependency>
-            <groupId>com.sap.hcp.cf.logging</groupId>
-            <artifactId>cf-java-logging-support-log4j2</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j2.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>${log4j2.version}</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
+		<dependency>
+			<groupId>org.glassfish.jersey.test-framework.providers</groupId>
+			<artifactId>jersey-test-framework-provider-grizzly2</artifactId>
+			<version>${jersey.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>javax.activation</groupId>
+			<artifactId>activation</artifactId>
+			<version>1.1.1</version>
+			<scope>test</scope>
+		</dependency>
+		<!-- we need our log4j2 implementation for testing! -->
+		<dependency>
+			<groupId>com.sap.hcp.cf.logging</groupId>
+			<artifactId>cf-java-logging-support-log4j2</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j-impl</artifactId>
+			<version>${log4j2.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>${log4j2.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
 </project>

--- a/cf-java-logging-support-log4j2/pom.xml
+++ b/cf-java-logging-support-log4j2/pom.xml
@@ -11,7 +11,7 @@
         <relativePath>../pom.xml</relativePath>
         <groupId>com.sap.hcp.cf.logging</groupId>
         <artifactId>cf-java-logging-support-parent</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.3</version>
     </parent>
 
     <dependencies>

--- a/cf-java-logging-support-logback/pom.xml
+++ b/cf-java-logging-support-logback/pom.xml
@@ -10,7 +10,7 @@
         <relativePath>../pom.xml</relativePath>
         <groupId>com.sap.hcp.cf.logging</groupId>
         <artifactId>cf-java-logging-support-parent</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.3</version>
     </parent>
 
     <dependencies>

--- a/cf-java-logging-support-servlet/pom.xml
+++ b/cf-java-logging-support-servlet/pom.xml
@@ -5,13 +5,13 @@
 	<artifactId>cf-java-logging-support-servlet</artifactId>
 	<packaging>jar</packaging>
 
-    <name>cf-java-logging-support-servlet</name>
-    <parent>
-        <groupId>com.sap.hcp.cf.logging</groupId>
-        <artifactId>cf-java-logging-support-parent</artifactId>
-        <version>3.0.2</version>
-        <relativePath>../pom.xml</relativePath>
-    </parent>
+	<name>cf-java-logging-support-servlet</name>
+	<parent>
+		<groupId>com.sap.hcp.cf.logging</groupId>
+		<artifactId>cf-java-logging-support-parent</artifactId>
+		<version>3.0.2</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
 
 	<properties>
 		<servlet.api.version>3.0.1</servlet.api.version>
@@ -69,5 +69,26 @@
 			<artifactId>jackson-databind</artifactId>
 			<version>2.9.9.1</version>
 		</dependency>
+
+		<!-- testing -->
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-server</artifactId>
+			<version>9.4.19.v20190610</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-servlet</artifactId>
+			<version>9.4.19.v20190610</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>4.5.9</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 </project>

--- a/cf-java-logging-support-servlet/pom.xml
+++ b/cf-java-logging-support-servlet/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.hcp.cf.logging</groupId>
 		<artifactId>cf-java-logging-support-parent</artifactId>
-		<version>3.0.2</version>
+		<version>3.0.3</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/cf-java-logging-support-servlet/pom.xml
+++ b/cf-java-logging-support-servlet/pom.xml
@@ -18,6 +18,21 @@
 	</properties>
 
 	<dependencies>
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.2.8</version>
+		</dependency>
+		<dependency>
+			<groupId>com.sun.xml.bind</groupId>
+			<artifactId>jaxb-core</artifactId>
+			<version>2.2.11</version>
+		</dependency>
+		<dependency>
+			<groupId>com.sun.xml.bind</groupId>
+			<artifactId>jaxb-impl</artifactId>
+			<version>2.2.11</version>
+		</dependency>
 		<!-- servlet api -->
 		<dependency>
 			<groupId>javax.servlet</groupId>

--- a/cf-java-logging-support-servlet/src/main/java/com/sap/hcp/cf/logging/servlet/filter/HttpHeaderUtilities.java
+++ b/cf-java-logging-support-servlet/src/main/java/com/sap/hcp/cf/logging/servlet/filter/HttpHeaderUtilities.java
@@ -3,6 +3,7 @@ package com.sap.hcp.cf.logging.servlet.filter;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.sap.hcp.cf.logging.common.LogContext;
 import com.sap.hcp.cf.logging.common.request.HttpHeader;
 
 public final class HttpHeaderUtilities {
@@ -25,12 +26,24 @@ public final class HttpHeaderUtilities {
 				return value;
 			}
 		}
+		String contextFieldValue = getLogContextFieldValue(header);
+		if (contextFieldValue != null) {
+			return contextFieldValue;
+		}
 		return defaultValue;
 	}
+
 
 	private static String getHeaderValueInternal(HttpServletRequest httpRequest, HttpHeader header) {
 		String headerName = header.getName();
 		return httpRequest.getHeader(headerName);
+	}
+
+	private static String getLogContextFieldValue(HttpHeader header) {
+		if (header.getField() == null) {
+			return null;
+		}
+		return LogContext.get(header.getField());
 	}
 
 	public static String getHeaderValue(HttpServletResponse httpResponse, HttpHeader header) {

--- a/cf-java-logging-support-servlet/src/main/java/com/sap/hcp/cf/logging/servlet/filter/RequestLoggingFilter.java
+++ b/cf-java-logging-support-servlet/src/main/java/com/sap/hcp/cf/logging/servlet/filter/RequestLoggingFilter.java
@@ -96,6 +96,10 @@ public class RequestLoggingFilter implements Filter {
 
 			RequestRecord rr = requestRecordFactory.create(httpRequest);
 			httpRequest.setAttribute(MDC.class.getName(), MDC.getCopyOfContextMap());
+			
+			if (!httpResponse.isCommitted() && httpResponse.getHeader(HttpHeaders.CORRELATION_ID.getName()) == null) {
+				httpResponse.setHeader(HttpHeaders.CORRELATION_ID.getName(), LogContext.getCorrelationId());
+			}
 
 			/*
 			 * -- we essentially do three things here: -- a) we create a log
@@ -133,6 +137,7 @@ public class RequestLoggingFilter implements Filter {
 			if (dynamicLogLevelProcessor != null) {
 				dynamicLogLevelProcessor.removeDynamicLogLevelFromMDC();
 			}
+			LogContext.resetContextFields();
 		}
 	}
 

--- a/cf-java-logging-support-servlet/src/test/java/com/sap/hcp/cf/logging/servlet/filter/RequestLogTest.java
+++ b/cf-java-logging-support-servlet/src/test/java/com/sap/hcp/cf/logging/servlet/filter/RequestLogTest.java
@@ -1,0 +1,221 @@
+package com.sap.hcp.cf.logging.servlet.filter;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.servlet.DispatcherType;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sap.hcp.cf.logging.common.Fields;
+import com.sap.hcp.cf.logging.common.LogContext;
+import com.sap.hcp.cf.logging.common.request.HttpHeader;
+import com.sap.hcp.cf.logging.common.request.HttpHeaders;
+
+public class RequestLogTest {
+
+	private static final Logger LOG = LoggerFactory.getLogger(RequestLogTest.class);
+	private static final String REQUEST_RECEIVED = "Request received";
+
+	@Rule
+	public SystemOutRule systemOut = new SystemOutRule();
+
+	private Server server;
+	private CloseableHttpClient client;
+
+	@Before
+	public void setUp() throws Exception {
+		this.server = initJetty();
+		this.client = HttpClientBuilder.create().build();
+
+	}
+
+	private Server initJetty() throws Exception {
+		Server server = new Server(0);
+		ServletContextHandler handler = new ServletContextHandler(server, null);
+		handler.addFilter(RequestLoggingFilter.class, "/*", EnumSet.of(DispatcherType.INCLUDE, DispatcherType.REQUEST,
+				DispatcherType.ERROR, DispatcherType.FORWARD, DispatcherType.ASYNC));
+		handler.addServlet(TestServlet.class, "/test");
+		server.start();
+		return server;
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		client.close();
+		server.stop();
+	}
+
+	@Test
+	public void logsCorrelationIdFromRequestHeader() throws Exception {
+		String correlationId = UUID.randomUUID().toString();
+		HttpGet get = new HttpGet(getBaseUrl() + "/test");
+		get.setHeader(HttpHeaders.CORRELATION_ID.getName(), correlationId);
+		CloseableHttpResponse response = null;
+		try {
+			response = client.execute(get);
+
+			assertNull("No correlation_id should be generated.", getCorrelationIdGenerated());
+
+			assertThat("Application log without correlation id.", getRequestMessage(),
+					hasEntry(Fields.CORRELATION_ID, correlationId));
+			assertThat("Request log without correlation id.", getRequestLog(),
+					hasEntry(Fields.CORRELATION_ID, correlationId));
+		} finally {
+			if (response != null) {
+				response.close();
+			}
+		}
+	}
+
+	@Test
+	public void logsGeneratedCorrelationId() throws Exception {
+		HttpGet get = new HttpGet(getBaseUrl() + "/test");
+		CloseableHttpResponse response = null;
+		try {
+			response = client.execute(get);
+
+			String correlationId = getCorrelationIdGenerated();
+
+			assertThat("Application log without correlation id.", getRequestMessage(),
+					hasEntry(Fields.CORRELATION_ID, correlationId));
+			assertThat("Request log without correlation id.", getRequestLog(),
+					hasEntry(Fields.CORRELATION_ID, correlationId));
+		} finally {
+			if (response != null) {
+				response.close();
+			}
+		}
+	}
+
+	@Test
+	public void logsRequestIdFromRequestHeader() throws Exception {
+		String requestId = UUID.randomUUID().toString();
+		HttpGet get = new HttpGet(getBaseUrl() + "/test");
+		get.setHeader(HttpHeaders.X_VCAP_REQUEST_ID.getName(), requestId);
+		CloseableHttpResponse response = null;
+		try {
+			response = client.execute(get);
+
+			assertThat("Application log without request id.", getRequestMessage(),
+					hasEntry(Fields.REQUEST_ID, requestId));
+			assertThat("Request log without request id.", getRequestLog(),
+					hasEntry(Fields.REQUEST_ID, requestId));
+		} finally {
+			if (response != null) {
+				response.close();
+			}
+		}
+	}
+
+	@Test
+	public void logsTenantIdFromRequestHeader() throws Exception {
+		String tenantId = UUID.randomUUID().toString();
+		HttpGet get = new HttpGet(getBaseUrl() + "/test");
+		get.setHeader(HttpHeaders.TENANT_ID.getName(), tenantId);
+		CloseableHttpResponse response = null;
+		try {
+			response = client.execute(get);
+
+			assertThat("Application log without tenant id.", getRequestMessage(),
+					hasEntry(Fields.TENANT_ID, tenantId));
+			assertThat("Request log without tenant id.", getRequestLog(), hasEntry(Fields.TENANT_ID, tenantId));
+		} finally {
+			if (response != null) {
+				response.close();
+			}
+		}
+	}
+
+	@Test
+	public void writesCorrelationIdFromHeadersAsResponseHeader() throws Exception {
+		String correlationId = UUID.randomUUID().toString();
+		HttpGet get = new HttpGet(getBaseUrl() + "/test");
+		get.setHeader(HttpHeaders.CORRELATION_ID.getName(), correlationId);
+		CloseableHttpResponse response = null;
+		try {
+			response = client.execute(get);
+			assertFirstHeaderValue(correlationId, response, HttpHeaders.CORRELATION_ID);
+		} finally {
+			if (response != null) {
+				response.close();
+			}
+		}
+	}
+
+	@Test
+	public void writesGeneratedCorrelationIdAsResponseHeader() throws Exception {
+		HttpGet get = new HttpGet(getBaseUrl() + "/test");
+		CloseableHttpResponse response = null;
+		try {
+			response = client.execute(get);
+
+			assertFirstHeaderValue(getCorrelationIdGenerated(), response, HttpHeaders.CORRELATION_ID);
+		} finally {
+			if (response != null) {
+				response.close();
+			}
+		}
+	}
+
+
+	private String getBaseUrl() {
+		int port = ((ServerConnector) server.getConnectors()[0]).getLocalPort();
+		return "http://localhost:" + port;
+	}
+
+	private String getCorrelationIdGenerated() throws IOException {
+		Map<Object, Object> generationLog = systemOut.fineLineAsMapWith("logger", LogContext.class.getName());
+		if (generationLog == null) {
+			return null;
+		}
+		return generationLog.get(Fields.CORRELATION_ID) == null ? null
+				: generationLog.get(Fields.CORRELATION_ID).toString();
+	}
+
+	private Map<Object, Object> getRequestMessage() throws IOException {
+		return systemOut.fineLineAsMapWith("msg", REQUEST_RECEIVED);
+	}
+
+	private Map<Object, Object> getRequestLog() throws IOException {
+		return systemOut.fineLineAsMapWith("layer", "[SERVLET]");
+	}
+
+	private static void assertFirstHeaderValue(String expected, CloseableHttpResponse response, HttpHeader header) {
+		String headerValue = response.getFirstHeader(header.getName()).getValue();
+		assertThat(headerValue, is(equalTo(expected)));
+	}
+
+	@SuppressWarnings("serial")
+	public static class TestServlet extends HttpServlet {
+
+		@Override
+		protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+			LOG.info(REQUEST_RECEIVED);
+		}
+	}
+}

--- a/cf-java-logging-support-servlet/src/test/java/com/sap/hcp/cf/logging/servlet/filter/RequestLoggingFilterTest.java
+++ b/cf-java-logging-support-servlet/src/test/java/com/sap/hcp/cf/logging/servlet/filter/RequestLoggingFilterTest.java
@@ -62,6 +62,7 @@ public class RequestLoggingFilterTest {
 
 	@Before
 	public void initMocks() throws IOException {
+		Mockito.reset(mockReq, mockResp, mockWriter);
 		when(mockResp.getWriter()).thenReturn(mockWriter);
 
 		Map<String, String> contextMap = new HashMap<>();

--- a/cf-java-logging-support-servlet/src/test/java/com/sap/hcp/cf/logging/servlet/filter/SystemOutRule.java
+++ b/cf-java-logging-support-servlet/src/test/java/com/sap/hcp/cf/logging/servlet/filter/SystemOutRule.java
@@ -1,10 +1,15 @@
 package com.sap.hcp.cf.logging.servlet.filter;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.util.Collections;
+import java.util.Map;
 
 import org.junit.rules.ExternalResource;
+
+import com.fasterxml.jackson.jr.ob.JSON;
 
 public class SystemOutRule extends ExternalResource {
 
@@ -27,4 +32,20 @@ public class SystemOutRule extends ExternalResource {
 	public String toString() {
 		return output.toString();
 	}
+
+	public Map<Object, Object> fineLineAsMapWith(String key, String expected) throws IOException {
+		for (String line : output.toString().split("\n")) {
+			Map<Object, Object> map = JSON.std.mapFrom(line);
+			if (expected.equals(getAsString(map, key))) {
+				return map;
+			}
+		}
+		return Collections.emptyMap();
+	}
+
+	private String getAsString(Map<Object, Object> map, String key) {
+		Object value = map.get(key);
+		return value != null ? value.toString() : null;
+	}
+
 }

--- a/cf-java-monitoring-custom-metrics-clients/cf-custom-metrics-clients-core/pom.xml
+++ b/cf-java-monitoring-custom-metrics-clients/cf-custom-metrics-clients-core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.sap.hcp.cf.logging</groupId>
 		<artifactId>cf-java-monitoring-custom-metrics-clients</artifactId>
-		<version>3.0.2</version>
+		<version>3.0.3</version>
 	</parent>
 
 	<artifactId>cf-custom-metrics-clients-core</artifactId>

--- a/cf-java-monitoring-custom-metrics-clients/cf-custom-metrics-clients-java/pom.xml
+++ b/cf-java-monitoring-custom-metrics-clients/cf-custom-metrics-clients-java/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.sap.hcp.cf.logging</groupId>
 		<artifactId>cf-java-monitoring-custom-metrics-clients</artifactId>
-		<version>3.0.2</version>
+		<version>3.0.3</version>
 	</parent>
 
 	<artifactId>cf-custom-metrics-clients-java</artifactId>

--- a/cf-java-monitoring-custom-metrics-clients/cf-custom-metrics-clients-spring-boot/pom.xml
+++ b/cf-java-monitoring-custom-metrics-clients/cf-custom-metrics-clients-spring-boot/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.sap.hcp.cf.logging</groupId>
         <artifactId>cf-java-monitoring-custom-metrics-clients</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.3</version>
     </parent>
 
     <artifactId>cf-custom-metrics-clients-spring-boot</artifactId>

--- a/cf-java-monitoring-custom-metrics-clients/pom.xml
+++ b/cf-java-monitoring-custom-metrics-clients/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.sap.hcp.cf.logging</groupId>
         <artifactId>cf-java-logging-support-parent</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.sap.hcp.cf.logging</groupId>
     <artifactId>cf-java-logging-support-parent</artifactId>
-    <version>3.0.2</version>
+    <version>3.0.3</version>
     <packaging>pom</packaging>
 
     <name>Cloud Foundry Java logging support components</name>

--- a/sample/manifest.yml
+++ b/sample/manifest.yml
@@ -5,7 +5,7 @@ applications:
 #
 - name: logging-sample-app
   instances: 1
-  path: target/logging-sample-app-3.0.2.war
+  path: target/logging-sample-app-3.0.3.war
   env:
     RANDOM_SLEEP: true
 # Set LOG_*: true to activate logging of respective field

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -18,7 +18,6 @@
         <slf4j.version>1.7.12</slf4j.version>
         <jersey.version>2.22.2</jersey.version>
         <javax.ws.version>2.0.1</javax.ws.version>
-        <cf-logging.version>3.0.3</cf-logging.version>
     </properties>
     <dependencies>
         <dependency>
@@ -75,7 +74,7 @@
         <dependency>
             <groupId>com.sap.hcp.cf.logging</groupId>
             <artifactId>cf-java-logging-support-log4j2</artifactId>
-            <version>${cf-logging.version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.sap.hcp.cf.logging</groupId>
         <artifactId>cf-java-logging-support-parent</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -18,7 +18,7 @@
         <slf4j.version>1.7.12</slf4j.version>
         <jersey.version>2.22.2</jersey.version>
         <javax.ws.version>2.0.1</javax.ws.version>
-        <cf-logging.version>3.0.2</cf-logging.version>
+        <cf-logging.version>3.0.3</cf-logging.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
* Log correlation_id in request log even when generate by RequestLoggingFilter
* Always add response header `X-CorrelationID` with correlation id