### PR TITLE
Fix Request Content-Length Calculation when using Reader

### DIFF
--- a/cf-java-logging-support-servlet/src/main/java/com/sap/hcp/cf/logging/servlet/filter/ContentLengthTrackingRequestWrapper.java
+++ b/cf-java-logging-support-servlet/src/main/java/com/sap/hcp/cf/logging/servlet/filter/ContentLengthTrackingRequestWrapper.java
@@ -35,7 +35,7 @@ public class ContentLengthTrackingRequestWrapper extends HttpServletRequestWrapp
     @Override
     public BufferedReader getReader() throws IOException {
         wrappedReader = new WrappedInputReader(super.getReader());
-        return wrappedReader;
+		return new BufferedReader(wrappedReader);
     }
 
     @Override

--- a/cf-java-logging-support-servlet/src/test/java/com/sap/hcp/cf/logging/servlet/filter/RequestLoggingFilterTest.java
+++ b/cf-java-logging-support-servlet/src/test/java/com/sap/hcp/cf/logging/servlet/filter/RequestLoggingFilterTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.StringReader;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -118,10 +119,9 @@ public class RequestLoggingFilterTest {
 
 	@Test
 	public void testReader() throws IOException, ServletException {
-		BufferedReader mockReader = mock(BufferedReader.class);
+		BufferedReader reader = new BufferedReader(new StringReader("TEST"));
 
-		when(mockReq.getReader()).thenReturn(mockReader);
-		when(mockReader.read()).thenReturn(1);
+		when(mockReq.getReader()).thenReturn(reader);
 		FilterChain mockFilterChain = new FilterChain() {
 			@Override
 			public void doFilter(ServletRequest request, ServletResponse response)
@@ -136,7 +136,7 @@ public class RequestLoggingFilterTest {
 		assertThat(getField(Fields.REMOTE_HOST), is(Defaults.UNKNOWN));
 		assertThat(getField(Fields.COMPONENT_ID), is(Defaults.UNKNOWN));
 		assertThat(getField(Fields.CONTAINER_ID), is(Defaults.UNKNOWN));
-		assertThat(getField(Fields.REQUEST_SIZE_B), is("1"));
+		assertThat(getField(Fields.REQUEST_SIZE_B), is("4"));
 		assertThat(getField(Fields.TENANT_ID), is(Defaults.UNKNOWN));
 	}
 

--- a/cf-java-logging-support-servlet/src/test/java/com/sap/hcp/cf/logging/servlet/filter/WrappedInputReaderTest.java
+++ b/cf-java-logging-support-servlet/src/test/java/com/sap/hcp/cf/logging/servlet/filter/WrappedInputReaderTest.java
@@ -1,0 +1,93 @@
+package com.sap.hcp.cf.logging.servlet.filter;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+
+import org.junit.Test;
+
+public class WrappedInputReaderTest {
+
+	private static final String MESSAGE = "ABCDEFGH";
+
+	private static WrappedInputReader wrap(String text) {
+		return new WrappedInputReader(new BufferedReader(new StringReader(text)));
+	}
+
+	@Test
+	public void unreadInputGivesMinusOne() throws Exception {
+		WrappedInputReader reader = wrap(MESSAGE);
+
+		assertThat(reader.getContentLength(), is(equalTo(-1)));
+	}
+
+	@Test
+	public void readSingleCharacter() throws Exception {
+		WrappedInputReader reader = wrap(MESSAGE);
+
+		int read = reader.read();
+		
+		assertThat((char) read, is(equalTo('A')));
+		assertThat(reader.getContentLength(), is(equalTo(1)));
+	}
+
+	@Test
+	public void readCharacterArray() throws Exception {
+		WrappedInputReader reader = wrap(MESSAGE);
+		char[] cbuf = new char[3];
+
+		reader.read(cbuf);
+
+		assertThat(new String(cbuf), is(equalTo("ABC")));
+		assertThat(reader.getContentLength(), is(equalTo(3)));
+	}
+
+	@Test
+	public void readCharacterArrayWithOffset() throws Exception {
+		WrappedInputReader reader = wrap(MESSAGE);
+
+		char[] cbuf = new char[5];
+		reader.read(cbuf, 1, 4);
+
+		assertThat(cbuf, is(equalTo(new char[] { 0, 'A', 'B', 'C', 'D' })));
+		assertThat(reader.getContentLength(), is(equalTo(4)));
+	}
+
+
+	@Test
+	public void skipCharacters() throws Exception {
+		WrappedInputReader reader = wrap(MESSAGE);
+
+		long skipped = reader.skip(3);
+
+		assertThat(reader.getContentLength(), is(equalTo((int) skipped)));
+	}
+
+	@Test
+	public void markAndReset() throws Exception {
+		WrappedInputReader reader = wrap(MESSAGE);
+
+		reader.mark(1);
+		int blind = reader.read();
+		reader.reset();
+		String text = consume(reader);
+
+		assertThat((char) blind, is(equalTo('A')));
+		assertThat(text, is(equalTo(MESSAGE)));
+		assertThat(reader.getContentLength(), is(equalTo(MESSAGE.length())));
+	}
+
+	private String consume(WrappedInputReader reader) throws IOException {
+		StringBuffer buffer = new StringBuffer();
+		int current;
+		while ((current = reader.read()) != -1) {
+			buffer.append((char) current);
+		}
+		return buffer.toString();
+	}
+
+}


### PR DESCRIPTION
Calculation of the HTTP request content-length was done using a decorator
pattern on the BufferedReader supplied by the HttpRequest of the Java Servlet
API. This has several problems:

* newline characters are filtered out in the BufferedReader implementation
* mark/reset was unsupported

The first issue was fixed, by decorating only the Reader interface and wrapping
the WrappedInputReader into another BufferedReader. The second issue was fixed
by a new implementation, that supports mark/reset. Corresponding test cases were
added.