### PR TITLE
Increase RSA key length for JWT Token

### DIFF
--- a/cf-java-logging-support-servlet/src/main/java/com/sap/hcp/cf/logging/servlet/dynlog/TokenCreator.java
+++ b/cf-java-logging-support-servlet/src/main/java/com/sap/hcp/cf/logging/servlet/dynlog/TokenCreator.java
@@ -62,7 +62,7 @@ public class TokenCreator {
 
         else {
             KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
-            keyGen.initialize(512);
+			keyGen.initialize(2048);
             keyPair = keyGen.generateKeyPair();
             // keyPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
         }


### PR DESCRIPTION
The example TokenCreator used a too small RSA key size for the JWT token.
The key length was increased according to the NIST recommendation.

adresses #53 