### PR TITLE
add tenant subdomain field

### DIFF
--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/Fields.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/Fields.java
@@ -14,6 +14,7 @@ public interface Fields {
   public String CORRELATION_ID = "correlation_id";
   public String REQUEST_ID = "request_id";
   public String TENANT_ID = "tenant_id";
+  public String TENANT_SUBDOMAIN = "tenant_subdomain";
   public String COMPONENT_ID = "component_id";
   public String COMPONENT_NAME = "component_name";
   public String COMPONENT_TYPE = "component_type";

--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/LogContext.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/LogContext.java
@@ -20,6 +20,7 @@ public class LogContext {
         {
             put(Fields.CORRELATION_ID, Defaults.UNKNOWN);
             put(Fields.TENANT_ID, Defaults.UNKNOWN);
+            put(Fields.TENANT_SUBDOMAIN, Defaults.UNKNOWN);
             put(Fields.REQUEST_ID, null);
             put(Fields.COMPONENT_ID, Defaults.UNKNOWN);
             put(Fields.COMPONENT_NAME, Defaults.UNKNOWN);


### PR DESCRIPTION
Hi colleagues,

I would like to suggest, to add the tenant subdomain add first class field.
I see many services that need to log the tenant information and also the specific tenant subdmain of the xsuaa.

Best regards
Stefan