### PR TITLE
Fix timestamp conversion to use current time

### DIFF
--- a/cf-java-logging-support-log4j2/src/main/java/com/sap/hcp/cf/log4j2/converter/TimestampConverter.java
+++ b/cf-java-logging-support-log4j2/src/main/java/com/sap/hcp/cf/log4j2/converter/TimestampConverter.java
@@ -21,7 +21,7 @@ public class TimestampConverter extends LogEventPatternConverter {
 
     @Override
     public void format(LogEvent event, StringBuilder toAppendTo) {
-        toAppendTo.append(System.nanoTime());
+        toAppendTo.append(System.currentTimeMillis() * 1000000);
     }
 
 }

--- a/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/logging/common/TestAppLog.java
+++ b/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/logging/common/TestAppLog.java
@@ -59,9 +59,9 @@ public class TestAppLog extends AbstractTest {
         MDC.put(SOME_KEY, SOME_VALUE);
         MDC.put("testNumeric", "200");
         logMsg = "Running testMDC()";
-        long beforeTS = System.nanoTime();
+        long beforeTS = System.currentTimeMillis() * 1000000;
         LOGGER.info(logMsg);
-        long afterTS = System.nanoTime();
+        long afterTS = System.currentTimeMillis() * 1000000;
         assertThat(getMessage(), is(logMsg));
         assertThat(getField(Fields.COMPONENT_ID), is("-"));
         assertThat(getField(Fields.COMPONENT_NAME), is("-"));

--- a/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/converter/TimestampConverter.java
+++ b/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/converter/TimestampConverter.java
@@ -14,7 +14,7 @@ public class TimestampConverter extends ClassicConverter {
     @Override
     public String convert(ILoggingEvent event) {
         StringBuilder appendTo = new StringBuilder();
-        appendTo.append(System.nanoTime());
+        appendTo.append(System.currentTimeMillis() * 1000000);
         return appendTo.toString();
     }
 

--- a/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logging/common/TestAppLog.java
+++ b/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logging/common/TestAppLog.java
@@ -61,7 +61,7 @@ public class TestAppLog extends AbstractTest {
         MDC.put(SOME_KEY, SOME_VALUE);
         MDC.put("testNumeric", "200");
         logMsg = "Running testMDC()";
-        long beforeTS = System.nanoTime();
+        long beforeTS = System.currentTimeMillis() * 1000000;
         LOGGER.info(logMsg);
         assertThat(getMessage(), is(logMsg));
         assertThat(getField(Fields.COMPONENT_ID), is("-"));


### PR DESCRIPTION
Replaced System.nanoTime() with System.currentTimeMillis(),
because nanoTime() is not related to the current real time, but rather an arbitrary starting point.