### PR TITLE
Consider x-correlation-id as well

### DIFF
--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/request/HttpHeaders.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/request/HttpHeaders.java
@@ -13,9 +13,14 @@ import com.sap.hcp.cf.logging.common.LogContext;
 
 public enum HttpHeaders implements HttpHeader {
 
-	CONTENT_LENGTH("content-length"), CONTENT_TYPE("content-type"), REFERER("referer"), X_FORWARDED_FOR(
-			"x-forwarded-for"), X_VCAP_REQUEST_ID("x-vcap-request-id"), CORRELATION_ID("X-CorrelationID",
-					Fields.CORRELATION_ID, true, X_VCAP_REQUEST_ID), TENANT_ID("tenantid", Fields.TENANT_ID, true);
+	CONTENT_LENGTH("content-length"),
+	CONTENT_TYPE("content-type"),
+	REFERER("referer"),
+	X_FORWARDED_FOR("x-forwarded-for"),
+	X_VCAP_REQUEST_ID("x-vcap-request-id"),
+	CORRELATION_ID("X-CorrelationID", Fields.CORRELATION_ID, true, X_CORRELATION_ID, X_VCAP_REQUEST_ID),
+	X_CORRELATION_ID("X-Correlation-ID"),
+	TENANT_ID("tenantid", Fields.TENANT_ID, true);
 
 	private HttpHeaders(String name) {
 		this(name, null, false);


### PR DESCRIPTION
The library currently considers the header fields `x-correlationid` and `x-vcap-request-id` as carrying correlation IDs. This change would also make it aware of the field `x-correlation-id`, which is widely used in the web, today.

The settings would introduce `x-correlation-id` as an alias, sub-ordinating it to the original field `x-correlationid`. Meaning, for example, the library will use `x-correlationid` > `x-correation-id` > `x-vcap-request-id`, in this order of preference. The field would not be propagated back to the request sender, although this can probably be discussed.

This PR is an incomplete suggestion, to make the dimension of the changes to the production code clear. It does not adjust the unit alongside, so any automatic PR voters will/should reject this change.