### PR TITLE
Add Test-Case for Custom Stacktraces

### DIFF
--- a/cf-java-logging-support-core/src/test/resources/com/sap/hcp/cf/logging/common/converter/stacktrace.txt
+++ b/cf-java-logging-support-core/src/test/resources/com/sap/hcp/cf/logging/common/converter/stacktrace.txt
@@ -1,0 +1,13 @@
+Insert your custom stacktrace here:
+
+Lorem ipsum dolor sit amet, 
+consectetur adipiscing elit, 
+sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+
+Ut enim ad minim veniam, 
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. 
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. 
+
+Excepteur sint occaecat cupidatat non proident, 
+sunt in culpa qui officia deserunt mollit anim id est laborum


### PR DESCRIPTION
On formatting issues with stacktraces it is helpful to easily pass them
through the StacktraceConverter. This can now be done with the provide
unit test.