### PR TITLE
Migrate Custom Fields JSON Serialization

### DIFF
--- a/cf-java-logging-support-core/beats/app-logs/docs/fields.asciidoc
+++ b/cf-java-logging-support-core/beats/app-logs/docs/fields.asciidoc
@@ -336,9 +336,23 @@ required: False
 A list of names to further categorize this log message.
 
 
-=== custom_fields Fields
+==== #cf
 
-A collection of non-standard fields as key-value pairs.
+type: object
+
+example: "#cf": {
+  "string": [
+    {"l":"some_label", "v":"some_value", "i": 0},
+    {"l":"other_label", "v":"other_value", "i": 1}
+  ]
+}
+
+
+required: False
+
+An object containing collections of non-standard fields.
+The field "string" contains custom fields with label "l", value "v" and an index "i".
+The index can be used for field order during parsing.
 
 NOTE: As this is "custom" there are no predefined fields here!
 

--- a/cf-java-logging-support-core/beats/app-logs/etc/fields.yml
+++ b/cf-java-logging-support-core/beats/app-logs/etc/fields.yml
@@ -249,11 +249,20 @@ app-logs:
       description: |
         A list of names to further categorize this log message.
 
-    - name: "custom_fields"
-      type: group
+    - name: "#cf"
+      java_alias: "CUSTOM_FIELDS"
+      type: object
       required: false
-      example: "cutom_fields: {\"some_key\": \"some_value\"}"
+      example: |
+        "#cf": {
+          "string": [
+            {"l":"some_label", "v":"some_value", "i": 0},
+            {"l":"other_label", "v":"other_value", "i": 1}
+          ]
+        }
       description: |
-        A collection of non-standard fields as key-value pairs.
+        An object containing collections of non-standard fields.
+        The field "string" contains custom fields with label "l", value "v" and an index "i".
+        The index can be used for field order during parsing.
 
         NOTE: As this is "custom" there are no predefined fields here!

--- a/cf-java-logging-support-core/beats/scripts/gen_java_fields.rb
+++ b/cf-java-logging-support-core/beats/scripts/gen_java_fields.rb
@@ -17,7 +17,9 @@ ARGV.each do |fname|
   spec.keys.each do |k|
     if spec[k].class == Hash && spec[k].has_key?('fields')
       spec[k]['fields'].each do |f|
-        fields.add(f['name'])
+        if fields.select { |c| c['name'].upcase == f['name'].upcase}.empty?
+          fields.add(f)
+        end
       end
     end
   end
@@ -37,7 +39,8 @@ public interface Fields {
 EOD
 
 fields.each do |f|
-  puts "  public String #{f.upcase} = \"#{f}\";"
+  key = f.has_key?('java_alias') ? f['java_alias'] : f['name']
+  puts "  public String #{key.upcase} = \"#{f['name']}\";"
 end
 
 puts "}"

--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/Fields.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/Fields.java
@@ -32,7 +32,7 @@ public interface Fields {
   public String MSG = "msg";
   public String STACKTRACE = "stacktrace";
   public String CATEGORIES = "categories";
-  public String CUSTOM_FIELDS = "custom_fields";
+  public String CUSTOM_FIELDS = "#cf";
   public String REQUEST = "request";
   public String REQUEST_SENT_AT = "request_sent_at";
   public String REQUEST_RECEIVED_AT = "request_received_at";

--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/converter/DefaultCustomFieldsConverter.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/converter/DefaultCustomFieldsConverter.java
@@ -1,56 +1,49 @@
 package com.sap.hcp.cf.logging.common.converter;
 
-import java.util.ArrayList;
+import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.ob.JSONComposer;
+import com.fasterxml.jackson.jr.ob.JSONObjectException;
+import com.fasterxml.jackson.jr.ob.comp.ArrayComposer;
 import com.fasterxml.jackson.jr.ob.comp.ObjectComposer;
 import com.sap.hcp.cf.logging.common.customfields.CustomField;
 
 public class DefaultCustomFieldsConverter {
 
-    private String fieldName = null;
-    private boolean embed = true;
+	private String fieldName = null;
+	private boolean embed = true;
+	private List<String> customFieldKeyNames;
 
-    public void setFieldName(String fieldName) {
-        if (fieldName != null) {
-            this.fieldName = fieldName;
-            embed = false;
-        }
-    }
+	public void setFieldName(String fieldName) {
+		if (fieldName != null) {
+			this.fieldName = fieldName;
+			embed = false;
+		}
+	}
 
-	public void convert(StringBuilder appendTo, Map<String, String> mdcCustomFields, Object... arguments) {
-		List<CustomField> customFields = getCustomFields(arguments);
+	public void setCustomFieldKeyNames(List<String> customFieldKeyNames) {
+		this.customFieldKeyNames = customFieldKeyNames;
+	}
+
+	public void convert(StringBuilder appendTo, Map<String, String> mdcPropertiesMap, Object... arguments) {
+		if (customFieldKeyNames.isEmpty()) {
+			return;
+		}
+		Map<String, CustomField> customFields = getRegisteredCustomFields(arguments);
+		Map<String, String> mdcCustomFields = getRegisteredMdcCustomFields(mdcPropertiesMap);
 		if (!customFields.isEmpty() || !mdcCustomFields.isEmpty()) {
 			try {
-				if (!embed) {
-					appendTo.append(JSON.std.asString(fieldName)).append(":");
-				}
-				/*
-				 * -- no matter whether we embed or not, it seems easier to
-				 * compose -- a JSON object from the key/value pairs. -- if we
-				 * embed that object, we simply chop off the outermost curly
-				 * braces.
-				 */
-				ObjectComposer<JSONComposer<String>> oc = JSON.std.composeString().startObject();
-				for (CustomField cf : customFields) {
-					oc.putObject(cf.getKey(), cf.getValue());
-				}
-				for (Map.Entry<String, String> mdcField : mdcCustomFields.entrySet()) {
-					oc.put(mdcField.getKey(), mdcField.getValue());
-				}
-				String result = oc.end().finish().trim();
-				if (embed) {
-					/* -- chop off curly braces -- */
-					appendTo.append(result.substring(1, result.length() - 1));
-				} else {
-					appendTo.append(result);
-				}
+				ArrayComposer<ObjectComposer<JSONComposer<String>>> oc = startJson(appendTo);
+				addCustomFields(oc, customFields, mdcCustomFields);
+				finishJson(oc, appendTo);
 			} catch (Exception ex) {
 				/* -- avoids substitute logger warnings on startup -- */
 				LoggerFactory.getLogger(DefaultCustomFieldsConverter.class).error("Conversion failed ", ex);
@@ -58,16 +51,74 @@ public class DefaultCustomFieldsConverter {
 		}
 	}
 
-	private List<CustomField> getCustomFields(Object[] arguments) {
-		if (arguments == null || arguments.length == 0) {
-			return Collections.emptyList();
+	private Map<String, String> getRegisteredMdcCustomFields(Map<String, String> mdcPropertiesMap) {
+		if (mdcPropertiesMap.isEmpty()) {
+			return Collections.emptyMap();
 		}
-		List<CustomField> customFields = new ArrayList<CustomField>();
-		for (Object argument : arguments) {
-			if (argument instanceof CustomField) {
-				customFields.add((CustomField) argument);
+		Map<String, String> mdcCustomFields = new HashMap<>(mdcPropertiesMap.size());
+		for (Map.Entry<String, String> current : mdcPropertiesMap.entrySet()) {
+			if (customFieldKeyNames.contains(current.getKey())) {
+				mdcCustomFields.put(current.getKey(), current.getValue());
 			}
 		}
-		return customFields;
+		return mdcCustomFields;
+	}
+
+	private Map<String, CustomField> getRegisteredCustomFields(Object... arguments) {
+		if (arguments == null) {
+			return Collections.emptyMap();
+		}
+		Map<String, CustomField> result = new HashMap<>();
+		for (Object current : arguments) {
+			if (current instanceof CustomField) {
+				CustomField field = (CustomField) current;
+				if (customFieldKeyNames.contains(field.getKey())) {
+					result.put(field.getKey(), field);
+				}
+			}
+		}
+		return result;
+	}
+
+	private ArrayComposer<ObjectComposer<JSONComposer<String>>> startJson(StringBuilder appendTo)
+			throws IOException, JSONObjectException, JsonProcessingException {
+		if (!embed) {
+			appendTo.append(JSON.std.asString(fieldName)).append(":");
+		}
+		/*
+		 * -- no matter whether we embed or not, it seems easier to compose -- a JSON
+		 * object from the key/value pairs. -- if we embed that object, we simply chop
+		 * off the outermost curly braces.
+		 */
+		return JSON.std.composeString().startObject().startArrayField("string");
+	}
+
+	private void addCustomFields(ArrayComposer<ObjectComposer<JSONComposer<String>>> oc,
+			Map<String, CustomField> customFields, Map<String, String> mdcCustomFields)
+			throws IOException, JsonProcessingException {
+		for (int i = 0; i < customFieldKeyNames.size(); i++) {
+			String key = customFieldKeyNames.get(i);
+			String value = mdcCustomFields.get(key);
+			// Let argument CustomField take precedence over MDC
+			CustomField field = customFields.get(key);
+			if (field != null) {
+				value = field.getValue();
+			}
+			if (value != null) {
+				oc.startObject().put("k", key).put("v", value).put("i", i).end();
+			}
+		}
+	}
+
+	private void finishJson(ArrayComposer<ObjectComposer<JSONComposer<String>>> oc, StringBuilder appendTo)
+			throws IOException, JsonProcessingException {
+		ObjectComposer<JSONComposer<String>> end = oc.end();
+		String result = end.end().finish().trim();
+		if (embed) {
+			/* -- chop off curly braces -- */
+			appendTo.append(result.substring(1, result.length() - 1));
+		} else {
+			appendTo.append(result);
+		}
 	}
 }

--- a/cf-java-logging-support-core/src/test/java/com/sap/hcp/cf/logging/common/converter/CustomFieldMatchers.java
+++ b/cf-java-logging-support-core/src/test/java/com/sap/hcp/cf/logging/common/converter/CustomFieldMatchers.java
@@ -1,0 +1,18 @@
+package com.sap.hcp.cf.logging.common.converter;
+
+import java.util.Map;
+
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+
+public final class CustomFieldMatchers {
+
+	private CustomFieldMatchers() {
+	}
+
+	public static Matcher<Map<? extends String, ? extends Object>> hasCustomField(String key, String value,
+			int index) {
+		return Matchers.both(Matchers.<String, Object>hasEntry("k", key))
+				.and(Matchers.<String, Object>hasEntry("v", value)).and(Matchers.<String, Object>hasEntry("i", index));
+	}
+}

--- a/cf-java-logging-support-core/src/test/java/com/sap/hcp/cf/logging/common/converter/DefaultCustomFieldsConverterTest.java
+++ b/cf-java-logging-support-core/src/test/java/com/sap/hcp/cf/logging/common/converter/DefaultCustomFieldsConverterTest.java
@@ -1,13 +1,15 @@
 package com.sap.hcp.cf.logging.common.converter;
 
-import static com.sap.hcp.cf.logging.common.converter.UnmarshallUtilities.unmarshal;
-import static com.sap.hcp.cf.logging.common.converter.UnmarshallUtilities.unmarshalPrefixed;
+import static com.sap.hcp.cf.logging.common.converter.CustomFieldMatchers.hasCustomField;
+import static com.sap.hcp.cf.logging.common.converter.UnmarshallUtilities.unmarshalCustomFields;
 import static com.sap.hcp.cf.logging.common.customfields.CustomField.customField;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasToString;
+import static org.hamcrest.Matchers.isEmptyString;
 import static org.junit.Assert.assertThat;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -17,12 +19,19 @@ import org.junit.Test;
 
 public class DefaultCustomFieldsConverterTest {
 
+	private static final String CUSTOM_KEY_0 = "custom_key_0";
+	private static final String CUSTOM_VALUE_0 = "custom_value_0";
+	private static final String CUSTOM_KEY_1 = "custom_key_1";
+	private static final String CUSTOM_VALUE_1 = "custom_value_1";
+	private static final String UNREGISTERED_KEY = "unregistered_key";
+	private static final String UNREGISTERED_VALUE = "unregistered_value";
 	private static final String HACK_ATTEMPT = "}{:\",\"";
 	private DefaultCustomFieldsConverter converter;
 
 	@Before
 	public void initConverter() {
 		this.converter = new DefaultCustomFieldsConverter();
+		converter.setCustomFieldKeyNames(Arrays.asList(CUSTOM_KEY_0, CUSTOM_KEY_1));
 	}
 
 	@Test
@@ -45,9 +54,21 @@ public class DefaultCustomFieldsConverterTest {
 	public void singleCustomFieldArgumentEmbedded() throws Exception {
 		StringBuilder sb = new StringBuilder();
 
-		converter.convert(sb, Collections.emptyMap(), customField("some key", "some value"));
+		converter.convert(sb, Collections.emptyMap(), customField(CUSTOM_KEY_0, CUSTOM_VALUE_0));
 
-		assertThat(unmarshal(sb), hasEntry("some key", "some value"));
+		assertThat(unmarshalCustomFields(sb), contains(hasCustomField(CUSTOM_KEY_0, CUSTOM_VALUE_0, 0)));
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void multipleCustomFieldArgumentEmbedded() throws Exception {
+		StringBuilder sb = new StringBuilder();
+
+		converter.convert(sb, Collections.emptyMap(), customField(CUSTOM_KEY_1, CUSTOM_VALUE_1),
+				customField(UNREGISTERED_KEY, UNREGISTERED_VALUE), customField(CUSTOM_KEY_0, CUSTOM_VALUE_0));
+
+		assertThat(unmarshalCustomFields(sb), containsInAnyOrder(hasCustomField(CUSTOM_KEY_0, CUSTOM_VALUE_0, 0),
+				hasCustomField(CUSTOM_KEY_1, CUSTOM_VALUE_1, 1)));
 	}
 
 	@Test
@@ -55,74 +76,99 @@ public class DefaultCustomFieldsConverterTest {
 		converter.setFieldName("prefix");
 		StringBuilder sb = new StringBuilder();
 
-		converter.convert(sb, Collections.emptyMap(), customField("some key", "some value"));
+		converter.convert(sb, Collections.emptyMap(), customField(CUSTOM_KEY_0, CUSTOM_VALUE_0));
 
-		assertThat(unmarshalPrefixed(sb, "prefix"), hasEntry("some key", "some value"));
+		assertThat(unmarshalCustomFields(sb, "prefix"), contains(hasCustomField(CUSTOM_KEY_0, CUSTOM_VALUE_0, 0)));
 	}
 
 	@Test
 	public void singleMdcField() throws Exception {
 		StringBuilder sb = new StringBuilder();
-		
+
 		@SuppressWarnings("serial")
 		Map<String, String> mdcFields = new HashMap<String, String>() {
 			{
-	        put("some key", "some value");
-	    }};
+				put(CUSTOM_KEY_0, CUSTOM_VALUE_0);
+			}
+		};
 
 		converter.convert(sb, mdcFields);
 
-		assertThat(unmarshal(sb), hasEntry("some key", "some value"));
+		assertThat(unmarshalCustomFields(sb), contains(hasCustomField(CUSTOM_KEY_0, CUSTOM_VALUE_0, 0)));
 	}
 
+	@SuppressWarnings("unchecked")
 	@Test
-	public void mergesMdcFieldsAndArguments() throws Exception {
+	public void multipleMdcFields() throws Exception {
 		StringBuilder sb = new StringBuilder();
 
 		@SuppressWarnings("serial")
 		Map<String, String> mdcFields = new HashMap<String, String>() {
 			{
-				put("mdc key", "mdc value");
+				put(CUSTOM_KEY_1, CUSTOM_VALUE_1);
+				put(UNREGISTERED_KEY, UNREGISTERED_VALUE);
+				put(CUSTOM_KEY_0, CUSTOM_VALUE_0);
 			}
 		};
 
-		converter.convert(sb, mdcFields, customField("some key", "some value"));
+		converter.convert(sb, mdcFields);
 
-		assertThat(unmarshal(sb),
-				allOf(hasEntry("some key", "some value"), hasEntry("mdc key", "mdc value")));
+		assertThat(unmarshalCustomFields(sb), containsInAnyOrder(hasCustomField(CUSTOM_KEY_0, CUSTOM_VALUE_0, 0),
+				hasCustomField(CUSTOM_KEY_1, CUSTOM_VALUE_1, 1)));
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void argumentsTakePrecendenceOverMdc() throws Exception {
+		StringBuilder sb = new StringBuilder();
+
+		@SuppressWarnings("serial")
+		Map<String, String> mdcFields = new HashMap<String, String>() {
+			{
+				put(CUSTOM_KEY_0, CUSTOM_VALUE_0);
+				put(CUSTOM_KEY_1, CUSTOM_VALUE_1);
+			}
+		};
+
+		converter.convert(sb, mdcFields, customField(CUSTOM_KEY_0, "preferred value"));
+
+		assertThat(unmarshalCustomFields(sb), containsInAnyOrder(hasCustomField(CUSTOM_KEY_0, "preferred value", 0),
+				hasCustomField(CUSTOM_KEY_1, CUSTOM_VALUE_1, 1)));
+	}
+
+	@Test
+	public void doesNotWriteJsonWhenNoFieldKeysAreConfigured() throws Exception {
+		StringBuilder sb = new StringBuilder();
+
+		converter.setCustomFieldKeyNames(Collections.emptyList());
+		converter.convert(sb, Collections.emptyMap(), customField(CUSTOM_KEY_0, CUSTOM_VALUE_0));
+
+		assertThat(sb.toString(), isEmptyString());
 	}
 
 	@Test
 	public void properlyEscapesValues() throws Exception {
 		StringBuilder sb = new StringBuilder();
 
-		converter.convert(sb, Collections.emptyMap(), customField("some key", HACK_ATTEMPT));
+		converter.convert(sb, Collections.emptyMap(), customField(CUSTOM_KEY_0, HACK_ATTEMPT));
 
-		assertThat(unmarshal(sb), hasEntry("some key", HACK_ATTEMPT));
-	}
-
-	@Test
-	public void properlyEscapesKeys() throws Exception {
-		StringBuilder sb = new StringBuilder();
-
-		converter.convert(sb, Collections.emptyMap(), customField(HACK_ATTEMPT, "some value"));
-
-		assertThat(unmarshal(sb), hasEntry(HACK_ATTEMPT, "some value"));
+		assertThat(unmarshalCustomFields(sb), contains(hasCustomField(CUSTOM_KEY_0, HACK_ATTEMPT, 0)));
 	}
 
 	@Test
 	public void properlyEscapesMdcFields() throws Exception {
 		StringBuilder sb = new StringBuilder();
-		
+
 		@SuppressWarnings("serial")
 		Map<String, String> mdcFields = new HashMap<String, String>() {
 			{
-				put(HACK_ATTEMPT, HACK_ATTEMPT);
-	    }};
+				put(CUSTOM_KEY_0, HACK_ATTEMPT);
+			}
+		};
 
 		converter.convert(sb, mdcFields);
 
-		assertThat(unmarshal(sb), hasEntry(HACK_ATTEMPT, HACK_ATTEMPT));
+		assertThat(unmarshalCustomFields(sb), contains(hasCustomField(CUSTOM_KEY_0, HACK_ATTEMPT, 0)));
 
 	}
 
@@ -131,10 +177,10 @@ public class DefaultCustomFieldsConverterTest {
 		converter.setFieldName(HACK_ATTEMPT);
 		StringBuilder sb = new StringBuilder();
 
-		converter.convert(sb, Collections.emptyMap(), customField("some key", "some value"));
+		converter.convert(sb, Collections.emptyMap(), customField(CUSTOM_KEY_0, CUSTOM_VALUE_0));
 
-		assertThat(unmarshalPrefixed(sb, HACK_ATTEMPT), hasEntry("some key", "some value"));
+		assertThat(unmarshalCustomFields(sb, HACK_ATTEMPT),
+				contains(hasCustomField(CUSTOM_KEY_0, CUSTOM_VALUE_0, 0)));
 	}
 
 }
-

--- a/cf-java-logging-support-core/src/test/java/com/sap/hcp/cf/logging/common/converter/UnmarshallUtilities.java
+++ b/cf-java-logging-support-core/src/test/java/com/sap/hcp/cf/logging/common/converter/UnmarshallUtilities.java
@@ -1,5 +1,6 @@
 package com.sap.hcp.cf.logging.common.converter;
 
+import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.jr.ob.JSON;
@@ -9,14 +10,26 @@ public final class UnmarshallUtilities {
 	private UnmarshallUtilities() {
 	}
 
-	public static Map<String, Object> unmarshal(StringBuilder sb) throws Exception {
-		return JSON.std.mapFrom("{" + sb.toString() + "}");
+	public static Map<String, Object> unmarshal(CharSequence sb) throws Exception {
+		String source = sb.toString().trim();
+		String json = isEnclosedInBrackets(source) ? source : "{" + source + "}";
+		return JSON.std.mapFrom(json);
+	}
+
+	private static boolean isEnclosedInBrackets(String source) {
+		return source.startsWith("{") && source.endsWith("}");
 	}
 
 	@SuppressWarnings("unchecked")
-	public static Map<String, Object> unmarshalPrefixed(StringBuilder sb, String prefix)
+	public static List<Map<String, Object>> unmarshalCustomFields(CharSequence sb) throws Exception {
+		return (List<Map<String, Object>>) unmarshal(sb).get("string");
+	}
+
+	@SuppressWarnings("unchecked")
+	public static List<Map<String, Object>> unmarshalCustomFields(CharSequence sb, String prefix)
 			throws Exception {
-		return (Map<String, Object>) unmarshal(sb).get(prefix);
+		Map<String, Object> prefixed = (Map<String, Object>) unmarshal(sb).get(prefix);
+		return (List<Map<String, Object>>) prefixed.get("string");
 	}
 
 }

--- a/cf-java-logging-support-log4j2/src/main/java/com/sap/hcp/cf/log4j2/converter/ContextPropsConverter.java
+++ b/cf-java-logging-support-log4j2/src/main/java/com/sap/hcp/cf/log4j2/converter/ContextPropsConverter.java
@@ -1,13 +1,16 @@
 package com.sap.hcp.cf.log4j2.converter;
 
 import java.util.Arrays;
+import java.util.Map;
 
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.pattern.ConverterKeys;
 import org.apache.logging.log4j.core.pattern.LogEventPatternConverter;
+import org.apache.logging.log4j.message.Message;
 
 import com.sap.hcp.cf.logging.common.converter.DefaultPropertiesConverter;
+import com.sap.hcp.cf.logging.common.customfields.CustomField;
 
 /**
  * A simple {@link LogEventPatternConverter} implementation that converts
@@ -43,7 +46,23 @@ public class ContextPropsConverter extends LogEventPatternConverter {
 
     @Override
     public void format(LogEvent event, StringBuilder toAppendTo) {
-        converter.convert(toAppendTo, event.getContextMap());
-    }
+		Map<String, String> contextData = event.getContextData().toMap();
+		addCustomFieldsFromArguments(contextData, event);
+		converter.convert(toAppendTo, contextData);
+	}
+
+	private void addCustomFieldsFromArguments(Map<String, String> contextData, LogEvent event) {
+		Message message = event.getMessage();
+		Object[] parameters = message.getParameters();
+		if (parameters == null) {
+			return;
+		}
+		for (Object current : parameters) {
+			if (current instanceof CustomField) {
+				CustomField field = (CustomField) current;
+				contextData.put(field.getKey(), field.getValue());
+			}
+		}
+	}
 
 }

--- a/cf-java-logging-support-log4j2/src/main/java/com/sap/hcp/cf/log4j2/converter/CustomFieldsConverter.java
+++ b/cf-java-logging-support-log4j2/src/main/java/com/sap/hcp/cf/log4j2/converter/CustomFieldsConverter.java
@@ -5,7 +5,6 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -15,7 +14,6 @@ import org.apache.logging.log4j.core.pattern.ConverterKeys;
 import org.apache.logging.log4j.core.pattern.LogEventPatternConverter;
 import org.apache.logging.log4j.core.pattern.PatternConverter;
 import org.apache.logging.log4j.message.Message;
-import org.apache.logging.log4j.util.BiConsumer;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
 
 import com.sap.hcp.cf.logging.common.converter.DefaultCustomFieldsConverter;
@@ -44,6 +42,7 @@ public class CustomFieldsConverter extends LogEventPatternConverter {
 		super(WORD, WORD);
 
 		customFieldMdcKeyNames = options == null ? emptyList() : unmodifiableList(asList(options));
+		converter.setCustomFieldKeyNames(customFieldMdcKeyNames);
 	}
 	
 	public static CustomFieldsConverter newInstance(final String[] options) {
@@ -66,26 +65,6 @@ public class CustomFieldsConverter extends LogEventPatternConverter {
 
 	private Map<String, String> getCustomFieldsFromMdc(LogEvent event) {
 		ReadOnlyStringMap contextData = event.getContextData();
-		if (contextData == null || contextData.isEmpty()) {
-			return Collections.emptyMap();
-		}
-		CustomFieldsMdcCollector mdcCollector = new CustomFieldsMdcCollector();
-		contextData.forEach(mdcCollector);
-		return mdcCollector.getCustomFields();
-	}
-
-	private class CustomFieldsMdcCollector implements BiConsumer<String, String> {
-		private Map<String, String> customFields = new HashMap<>(customFieldMdcKeyNames.size());
-
-		@Override
-		public void accept(String key, String value) {
-			if (customFieldMdcKeyNames.contains(key)) {
-				customFields.put(key, value);
-			}
-		}
-
-		public Map<String, String> getCustomFields() {
-			return customFields;
-		}
+		return contextData != null ? contextData.toMap() : Collections.emptyMap();
 	}
 }

--- a/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/log4j2/converter/AbstractConverterTest.java
+++ b/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/log4j2/converter/AbstractConverterTest.java
@@ -43,7 +43,7 @@ public abstract class AbstractConverterTest {
         return sb.toString();
     }
 
-    protected LogEvent makeEvent(String msg, Object[] args) {
+	protected LogEvent makeEvent(String msg, Object... args) {
         return makeEvent(msg, null, args);
     }
 

--- a/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/log4j2/converter/CustomFieldsConverterTest.java
+++ b/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/log4j2/converter/CustomFieldsConverterTest.java
@@ -116,7 +116,7 @@ public class CustomFieldsConverterTest {
 		converter.format(event, sb);
 
 		verifyConverterCall(allOf(hasEntry("this key", "this value"), hasEntry("that key", "that value"),
-				not(hasEntry("other key", "other value"))));
+				hasEntry("other key", "other value")));
 	}
 
 	@Test
@@ -129,7 +129,7 @@ public class CustomFieldsConverterTest {
 		converter.format(event, sb);
 
 		verifyConverterCall(allOf(hasEntry("this key", "this value"), hasEntry("that key", "that value"),
-				not(hasEntry("other key", "other value"))), is(sameInstance(customField)));
+				hasEntry("other key", "other value")), is(sameInstance(customField)));
 
 	}
 

--- a/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/log4j2/layout/LayoutPatternBuilderTest.java
+++ b/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/log4j2/layout/LayoutPatternBuilderTest.java
@@ -51,7 +51,7 @@ public class LayoutPatternBuilderTest {
 	public void customFields() throws Exception {
 		String pattern = new LayoutPatternBuilder().addCustomFields(Arrays.asList("this key", "that key")).build();
 
-		assertThat(pattern, specificPart(is(",\"custom_fields\":{%cf{this key}{that key}}")));
+		assertThat(pattern, specificPart(is(",\"#cf\":{%cf{this key}{that key}}")));
 	}
 
 	@Test
@@ -83,7 +83,7 @@ public class LayoutPatternBuilderTest {
 				.suppressExceptions().build();
 
 		assertThat(pattern, specificPart(is(
-				",\"type\":\"log\",\"logger\":\"%replace{%logger}{\"}{\\\\\"}\",\"thread\":\"%replace{%thread}{\"}{\\\\\"}\",\"level\":\"%p\",\"categories\":%categories,\"msg\":%jsonmsg{escape},%ctxp{excluded-field},\"custom_fields\":{%cf{custom-field}}%ex{0} ")));
+				",\"type\":\"log\",\"logger\":\"%replace{%logger}{\"}{\\\\\"}\",\"thread\":\"%replace{%thread}{\"}{\\\\\"}\",\"level\":\"%p\",\"categories\":%categories,\"msg\":%jsonmsg{escape},%ctxp{excluded-field},\"#cf\":{%cf{custom-field}}%ex{0} ")));
 	}
 
 	@Test
@@ -93,7 +93,7 @@ public class LayoutPatternBuilderTest {
 				.build();
 
 		assertThat(pattern, specificPart(is(
-				",\"type\":\"log\",\"logger\":\"%replace{%logger}{\"}{\\\\\"}\",\"thread\":\"%replace{%thread}{\"}{\\\\\"}\",\"level\":\"%p\",\"categories\":%categories,\"msg\":%jsonmsg{escape},%ctxp{excluded-field},\"custom_fields\":{%cf{custom-field}},\"stacktrace\":%stacktrace")));
+				",\"type\":\"log\",\"logger\":\"%replace{%logger}{\"}{\\\\\"}\",\"thread\":\"%replace{%thread}{\"}{\\\\\"}\",\"level\":\"%p\",\"categories\":%categories,\"msg\":%jsonmsg{escape},%ctxp{excluded-field},\"#cf\":{%cf{custom-field}},\"stacktrace\":%stacktrace")));
 	}
 
 	private static Matcher<String> specificPart(Matcher<String> expected) {

--- a/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/logging/common/AbstractTest.java
+++ b/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/logging/common/AbstractTest.java
@@ -66,7 +66,7 @@ public abstract class AbstractTest {
     }
 
     protected String getCustomField(String fieldName) {
-        Map<String, Object> cfMap = getMap("custom_fields");
+		Map<String, Object> cfMap = getMap(Fields.CUSTOM_FIELDS);
         Object fObj = cfMap.get(fieldName);
         if (fObj != null) {
             return fObj.toString();

--- a/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/logging/common/AbstractTest.java
+++ b/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/logging/common/AbstractTest.java
@@ -1,5 +1,7 @@
 package com.sap.hcp.cf.logging.common;
 
+import static com.sap.hcp.cf.logging.common.converter.UnmarshallUtilities.unmarshalCustomFields;
+
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.List;
@@ -12,11 +14,18 @@ import com.fasterxml.jackson.jr.ob.JSON;
 
 public abstract class AbstractTest {
 
-    public static final String TEST_MESSAGE = "this is a test message";
+	public static final String TEST_MESSAGE = "this is a test message";
+	// see log4j2-test.xml for valid field keys and indices
+	public static final String CUSTOM_FIELD_KEY = "custom-field";
+	public static final int CUSTOM_FIELD_INDEX = 0;
+	public static final String TEST_FIELD_KEY = "test-field";
+	public static final int TEST_FIELD_INDEX = 1;
+	public static final String RETAINED_FIELD_KEY = "retained-field";
+	public static final int RETAINED_FIELD_INDEX = 2;
     public static final String SOME_KEY = "some_key";
     public static final String SOME_VALUE = "some value";
-    public static final String SOME_OTHER_KEY = "some_other_key";
     public static final String SOME_OTHER_VALUE = "some other value";
+	public static final String HACK_ATTEMPT = "}{:\",\"";
 
     protected final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
     protected final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
@@ -65,14 +74,16 @@ public abstract class AbstractTest {
         return lines[lines.length - 1];
     }
 
-    protected String getCustomField(String fieldName) {
-		Map<String, Object> cfMap = getMap(Fields.CUSTOM_FIELDS);
-        Object fObj = cfMap.get(fieldName);
-        if (fObj != null) {
-            return fObj.toString();
-        }
-        return null;
-    }
+	protected Map<String, Object> getCustomField(String fieldName) throws Exception {
+		List<Map<String, Object>> fields = unmarshalCustomFields(outContent.toString(),
+				Fields.CUSTOM_FIELDS);
+		for (Map<String, Object> field : fields) {
+			if (fieldName.equals(field.get("k"))) {
+				return field;
+			}
+		}
+		return null;
+	}
 
     @SuppressWarnings("unchecked")
     protected Map<String, Object> getMap(String fieldName) {

--- a/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/logging/common/TestCustomFields.java
+++ b/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/logging/common/TestCustomFields.java
@@ -30,6 +30,14 @@ public class TestCustomFields extends AbstractTest {
 	}
 
 	@Test
+	public void testCustomFieldWithoutRegistration() throws Exception {
+		LOGGER.info(TEST_MESSAGE, customField("ungregistered", SOME_VALUE));
+
+		assertThat(getField("ungregistered"), is(SOME_VALUE));
+		assertThat(getCustomField("unregistered"), is(nullValue()));
+	}
+
+	@Test
 	public void testCustomFieldAsPartOfMessage() throws Exception {
 		String messageWithPattern = TEST_MESSAGE + " {}";
 		String messageWithKeyValue = TEST_MESSAGE + " " + CUSTOM_FIELD_KEY + "=" + SOME_VALUE;

--- a/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/logging/common/TestCustomFields.java
+++ b/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/logging/common/TestCustomFields.java
@@ -86,7 +86,7 @@ public class TestCustomFields extends AbstractTest {
     }
 
     private String getCustomFields() {
-        return getField("custom_fields");
+		return getField(Fields.CUSTOM_FIELDS);
     }
 
 	@Test

--- a/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/logging/common/TestCustomFields.java
+++ b/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/logging/common/TestCustomFields.java
@@ -1,10 +1,9 @@
 package com.sap.hcp.cf.logging.common;
 
+import static com.sap.hcp.cf.logging.common.converter.CustomFieldMatchers.hasCustomField;
 import static com.sap.hcp.cf.logging.common.customfields.CustomField.customField;
-import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.text.StringContainsInOrder.stringContainsInOrder;
 import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
@@ -14,101 +13,89 @@ import org.slf4j.MDC;
 
 public class TestCustomFields extends AbstractTest {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(TestCustomFields.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(TestCustomFields.class);
 
-    @Test
-    public void testLogMessage() {
-        LOGGER.info(TEST_MESSAGE);
-        assertThat(getMessage(), is(TEST_MESSAGE));
-    }
+	@Test
+	public void testLogMessage() {
+		LOGGER.info(TEST_MESSAGE);
+		assertThat(getMessage(), is(TEST_MESSAGE));
+	}
 
-    @Test
-    public void testLogMessageWithCustomField() {
-        LOGGER.info(TEST_MESSAGE, customField(SOME_KEY, SOME_VALUE));
+	@Test
+	public void testLogMessageWithCustomField() throws Exception {
+		LOGGER.info(TEST_MESSAGE, customField(CUSTOM_FIELD_KEY, SOME_VALUE));
 
-        assertThat(getMessage(), is(TEST_MESSAGE));
-        assertThat(getCustomField(SOME_KEY), is(SOME_VALUE));
-    }
+		assertThat(getMessage(), is(TEST_MESSAGE));
+		assertThat(getCustomField(CUSTOM_FIELD_KEY), hasCustomField(CUSTOM_FIELD_KEY, SOME_VALUE, CUSTOM_FIELD_INDEX));
+	}
 
-    @Test
-    public void testCustomFieldAsPartOfMessage() {
-        String messageWithPattern = TEST_MESSAGE + " {}";
-        String messageWithKeyValue = TEST_MESSAGE + " " + SOME_KEY + "=" + SOME_VALUE;
+	@Test
+	public void testCustomFieldAsPartOfMessage() throws Exception {
+		String messageWithPattern = TEST_MESSAGE + " {}";
+		String messageWithKeyValue = TEST_MESSAGE + " " + CUSTOM_FIELD_KEY + "=" + SOME_VALUE;
 
-        LOGGER.info(messageWithPattern, customField(SOME_KEY, SOME_VALUE));
+		LOGGER.info(messageWithPattern, customField(CUSTOM_FIELD_KEY, SOME_VALUE));
 
-        assertThat(getMessage(), is(messageWithKeyValue));
-        assertThat(getCustomField(SOME_KEY), is(SOME_VALUE));
-    }
+		assertThat(getMessage(), is(messageWithKeyValue));
+		assertThat(getCustomField(CUSTOM_FIELD_KEY), hasCustomField(CUSTOM_FIELD_KEY, SOME_VALUE, CUSTOM_FIELD_INDEX));
+	}
 
-    @Test
-    public void testEscape() {
-        String messageWithPattern = TEST_MESSAGE + " {}";
-        String strangeCharacters = "}{:\",\"";
-        String messageWithKeyValue = TEST_MESSAGE + " " + SOME_KEY + "=" + strangeCharacters;
+	@Test
+	public void testEscape() throws Exception {
+		String messageWithPattern = TEST_MESSAGE + " {}";
+		String messageWithKeyValue = TEST_MESSAGE + " " + CUSTOM_FIELD_KEY + "=" + HACK_ATTEMPT;
 
-        LOGGER.info(messageWithPattern, customField(SOME_KEY, strangeCharacters));
+		LOGGER.info(messageWithPattern, customField(CUSTOM_FIELD_KEY, HACK_ATTEMPT));
 
-        assertThat(getMessage(), is(messageWithKeyValue));
-        assertThat(getCustomField(SOME_KEY), is(strangeCharacters));
-    }
+		assertThat(getMessage(), is(messageWithKeyValue));
+		assertThat(getCustomField(CUSTOM_FIELD_KEY),
+				hasCustomField(CUSTOM_FIELD_KEY, HACK_ATTEMPT, CUSTOM_FIELD_INDEX));
+	}
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testNullKey() {
-        customField(null, SOME_VALUE);
-    }
+	@Test(expected = IllegalArgumentException.class)
+	public void testNullKey() {
+		customField(null, SOME_VALUE);
+	}
 
-    @Test
-    public void testNullValue() {
-        LOGGER.info(TEST_MESSAGE, customField(SOME_KEY, null));
+	@Test
+	public void testNullValue() throws Exception {
+		LOGGER.info(TEST_MESSAGE, customField(CUSTOM_FIELD_KEY, null));
 
-        assertThat(getMessage(), is(TEST_MESSAGE));
-        assertThat(getCustomField(SOME_KEY), is("null"));
-    }
+		assertThat(getMessage(), is(TEST_MESSAGE));
+		assertThat(getCustomField(CUSTOM_FIELD_KEY), hasCustomField(CUSTOM_FIELD_KEY, "null", CUSTOM_FIELD_INDEX));
+	}
 
-    @Test
-    public void testLogMessageWithTwoCustomFields() {
-        LOGGER.info(TEST_MESSAGE, customField(SOME_KEY, SOME_VALUE), customField(SOME_OTHER_KEY, SOME_OTHER_VALUE));
+	@Test
+	public void testLogMessageWithTwoCustomFields() throws Exception {
+		LOGGER.info(TEST_MESSAGE, customField(TEST_FIELD_KEY, SOME_VALUE),
+				customField(CUSTOM_FIELD_KEY, SOME_OTHER_VALUE));
 
-        assertThat(getMessage(), is(TEST_MESSAGE));
+		assertThat(getMessage(), is(TEST_MESSAGE));
 
-        assertThat(getCustomField(SOME_KEY), is(SOME_VALUE));
-        assertThat(getCustomField(SOME_OTHER_KEY), is(SOME_OTHER_VALUE));
-    }
-
-    @Test
-    public void testOrderOfLogMessageWithTwoCustomFields() {
-        LOGGER.info(TEST_MESSAGE, customField(SOME_KEY, SOME_VALUE), customField(SOME_OTHER_KEY, SOME_OTHER_VALUE));
-
-        String jsonString = getCustomFields();
-        assertThat(jsonString, stringContainsInOrder(asList(SOME_KEY, SOME_OTHER_KEY)));
-        assertThat(jsonString, stringContainsInOrder(asList(SOME_VALUE, SOME_OTHER_VALUE)));
-    }
-
-    private String getCustomFields() {
-		return getField(Fields.CUSTOM_FIELDS);
-    }
+		assertThat(getCustomField(TEST_FIELD_KEY), hasCustomField(TEST_FIELD_KEY, SOME_VALUE, TEST_FIELD_INDEX));
+		assertThat(getCustomField(CUSTOM_FIELD_KEY),
+				hasCustomField(CUSTOM_FIELD_KEY, SOME_OTHER_VALUE, CUSTOM_FIELD_INDEX));
+	}
 
 	@Test
 	public void testCustomFieldFromMdcWithoutRetention() throws Exception {
-		// see log4j2-test.xml for valid field keys
-		MDC.put("test-field", "test-value");
+		MDC.put(TEST_FIELD_KEY, SOME_VALUE);
 
 		LOGGER.info(TEST_MESSAGE);
 
-		assertThat(getCustomField("test-field"), is("test-value"));
-		assertThat(getField("test-field"), is(nullValue()));
+		assertThat(getCustomField(TEST_FIELD_KEY), hasCustomField(TEST_FIELD_KEY, SOME_VALUE, TEST_FIELD_INDEX));
+		assertThat(getField(TEST_FIELD_KEY), is(nullValue()));
 	}
 
 	@Test
 	public void testCustomFieldFromMdcWithRetention() throws Exception {
-		// see log4j2-test.xml for valid field keys
-		MDC.put("retained-field", "test-value");
+		MDC.put(RETAINED_FIELD_KEY, SOME_VALUE);
 
 		LOGGER.info(TEST_MESSAGE);
 
-		assertThat(getCustomField("retained-field"), is("test-value"));
-		assertThat(getField("retained-field"), is("test-value"));
+		assertThat(getCustomField(RETAINED_FIELD_KEY),
+				hasCustomField(RETAINED_FIELD_KEY, SOME_VALUE, RETAINED_FIELD_INDEX));
+		assertThat(getField(RETAINED_FIELD_KEY), is(SOME_VALUE));
 	}
 
 }

--- a/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/converter/ContextPropsConverter.java
+++ b/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/converter/ContextPropsConverter.java
@@ -1,10 +1,13 @@
 package com.sap.hcp.cf.logback.converter;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.sap.hcp.cf.logging.common.LogContext;
 import com.sap.hcp.cf.logging.common.converter.DefaultPropertiesConverter;
+import com.sap.hcp.cf.logging.common.customfields.CustomField;
 
 import ch.qos.logback.classic.pattern.ClassicConverter;
 import ch.qos.logback.classic.spi.ILoggingEvent;
@@ -40,8 +43,24 @@ public class ContextPropsConverter extends ClassicConverter {
 	public String convert(ILoggingEvent event) {
 		StringBuilder appendTo = new StringBuilder();
 		LogContext.loadContextFields();
-		converter.convert(appendTo, event.getMDCPropertyMap());
+		Map<String, String> propertyMap = new HashMap<>(event.getMDCPropertyMap());
+		addCustomFieldsFromArgument(propertyMap, event);
+		converter.convert(appendTo, propertyMap);
 		return appendTo.toString();
+	}
+
+	private void addCustomFieldsFromArgument(Map<String, String> propertyMap, ILoggingEvent event) {
+		Object[] arguments = event.getArgumentArray();
+		if (arguments == null) {
+			return;
+		}
+		for (Object current : arguments) {
+			if (current instanceof CustomField) {
+				CustomField field = (CustomField) current;
+				propertyMap.put(field.getKey(), field.getValue());
+			}
+
+		}
 	}
 
 	@Override

--- a/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/converter/CustomFieldsAdapter.java
+++ b/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/converter/CustomFieldsAdapter.java
@@ -5,10 +5,7 @@ import static java.util.Collections.unmodifiableList;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import com.sap.hcp.cf.logging.common.LogContext;
 
@@ -54,16 +51,8 @@ public class CustomFieldsAdapter {
 		return customFieldExclusions;
 	}
 
-	public Map<String, String> selectCustomFields(Map<String, String> in) {
-		if (in == null) {
-			return Collections.emptyMap();
-		}
-		HashMap<String, String> result = new HashMap<>(in.size());
-		for (Map.Entry<String, String> current : in.entrySet()) {
-			if (customFieldMdcKeyNames.contains(current.getKey())) {
-				result.put(current.getKey(), current.getValue());
-			}
-		}
-		return result;
+	public List<String> getCustomFieldMdcKeyNames() {
+		return customFieldMdcKeyNames;
 	}
+
 }

--- a/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/converter/CustomFieldsConverter.java
+++ b/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/converter/CustomFieldsConverter.java
@@ -27,7 +27,6 @@ public class CustomFieldsConverter extends ClassicConverter {
 	private DefaultCustomFieldsConverter converter = new DefaultCustomFieldsConverter();
 	private CustomFieldsAdapter customFieldsAdapter = new CustomFieldsAdapter();
 	
-
 	void setConverter(DefaultCustomFieldsConverter converter) {
 		this.converter = converter;
 	}
@@ -47,14 +46,14 @@ public class CustomFieldsConverter extends ClassicConverter {
 
 	private Map<String, String> getMdcCustomFields(ILoggingEvent event) {
 		LogContext.loadContextFields();
-		Map<String, String> mdcPropertyMap = event.getMDCPropertyMap();
-		return customFieldsAdapter.selectCustomFields(mdcPropertyMap);
+		return event.getMDCPropertyMap();
 	}
 
 	@Override
 	public void start() {
-		converter.setFieldName(getFirstOption());
 		customFieldsAdapter.initialize(getContext());
+		converter.setFieldName(getFirstOption());
+		converter.setCustomFieldKeyNames(customFieldsAdapter.getCustomFieldMdcKeyNames());
 		super.start();
 	}
 }

--- a/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/encoder/LayoutPatterns.java
+++ b/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/encoder/LayoutPatterns.java
@@ -38,7 +38,8 @@ public final class LayoutPatterns {
 			+ JSON_FIELD(Fields.LOGGER, "%replace(%logger){'\"','\\\\\"'}", true, true)
 			+ JSON_FIELD(Fields.THREAD, "%replace(%thread){'\"','\\\\\"'}", true, true)
 			+ JSON_FIELD(Fields.LEVEL, "%p", true, true) + JSON_FIELD(Fields.CATEGORIES, "%categories", false, true)
-			+ JSON_FIELD(Fields.MSG, "%jsonmsg{escape}%replace(%args{custom_fields}){'(.+)', ',$1'}", false, false);
+			+ JSON_FIELD(Fields.MSG, "%jsonmsg{escape}%replace(%args{" + Fields.CUSTOM_FIELDS + "}){'(.+)', ',$1'}",
+					false, false);
 
 	/*
 	 * -- a simple application log message does not include exception/stack trace

--- a/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logback/converter/CustomFieldsAdapterTest.java
+++ b/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logback/converter/CustomFieldsAdapterTest.java
@@ -4,16 +4,12 @@ package com.sap.hcp.cf.logback.converter;
 import static com.sap.hcp.cf.logback.converter.CustomFieldsAdapter.OPTION_MDC_CUSTOM_FIELDS;
 import static com.sap.hcp.cf.logback.converter.CustomFieldsAdapter.OPTION_MDC_RETAINED_FIELDS;
 import static java.util.Arrays.asList;
-import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -45,62 +41,6 @@ public class CustomFieldsAdapterTest {
 
 	@InjectMocks
 	private CustomFieldsAdapter adapter;
-
-	@Test
-	public void rejectsAllFieldsWithoutContext() throws Exception {
-		adapter.initialize(null);
-
-		Map<String, String> selected = adapter.selectCustomFields(ALL_ENTRIES);
-
-		assertThat(selected.entrySet(), is(empty()));
-	}
-
-	@Test
-	public void rejectsAllFieldsWithoutConfigObject() throws Exception {
-		adapter.initialize(context);
-
-		Map<String, String> selected = adapter.selectCustomFields(ALL_ENTRIES);
-
-		assertThat(selected.entrySet(), is(empty()));
-	}
-
-	@Test
-	public void rejectsAllFieldsWithImproperConfigObject() throws Exception {
-		when(context.getObject(OPTION_MDC_CUSTOM_FIELDS)).thenReturn(new Object());
-		adapter.initialize(context);
-
-		Map<String, String> selected = adapter.selectCustomFields(ALL_ENTRIES);
-
-		assertThat(selected.entrySet(), is(empty()));
-	}
-
-	@Test
-	public void rejectsAllFieldsWithEmptyList() throws Exception {
-		when(context.getObject(OPTION_MDC_CUSTOM_FIELDS)).thenReturn(Collections.emptyList());
-		adapter.initialize(context);
-
-		Map<String, String> selected = adapter.selectCustomFields(ALL_ENTRIES);
-
-		assertThat(selected.entrySet(), is(empty()));
-	}
-
-	@Test
-	public void selectsConfiguredFields() throws Exception {
-		when(context.getObject(OPTION_MDC_CUSTOM_FIELDS)).thenReturn(asList("this key", "that key"));
-		adapter.initialize(context);
-
-		Map<String, String> selected = adapter.selectCustomFields(ALL_ENTRIES);
-
-		assertThat(selected, allOf(hasEntry("this key", "this value"), hasEntry("that key", "that value"),
-				not(hasEntry("other key", "other value"))));
-	}
-
-	@Test
-	public void selectsEmptyMapOnNullInput() throws Exception {
-		Map<String, String> selected = adapter.selectCustomFields(null);
-
-		assertThat(selected.entrySet(), is(empty()));
-	}
 
 	@Test
 	public void emptyExclusionsWithoutContext() throws Exception {

--- a/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logback/converter/CustomFieldsConverterTest.java
+++ b/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logback/converter/CustomFieldsConverterTest.java
@@ -10,7 +10,6 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -114,26 +113,10 @@ public class CustomFieldsConverterTest extends AbstractConverterTest {
 	}
 
 
-	@SuppressWarnings("serial")
-	@Test
-	public void singleUnconfiguredMdcField() throws Exception {
-		converter.start();
-		when(event.getMDCPropertyMap()).thenReturn(new HashMap<String, String>() {
-			{
-				put("some key", "some value");
-			}
-		});
-
-		converter.convert(event);
-
-		verifyConverterCall(emptyMap(), nullValue());
-	}
 
 	@Test
-	public void singleConfiguredMdcField() throws Exception {
-		Map<String, String> someMap = new HashMap<>();
-		when(event.getMDCPropertyMap()).thenReturn(someMap);
-		when(customFieldsAdapter.selectCustomFields(eq(someMap))).thenReturn(MDC_PROPERTIES);
+	public void singleMdcField() throws Exception {
+		when(event.getMDCPropertyMap()).thenReturn(MDC_PROPERTIES);
 		converter.start();
 
 		converter.convert(event);
@@ -143,9 +126,7 @@ public class CustomFieldsConverterTest extends AbstractConverterTest {
 
 	@Test
 	public void mergesMdcFieldsAndArguments() throws Exception {
-		Map<String, String> someMap = new HashMap<>();
-		when(event.getMDCPropertyMap()).thenReturn(someMap);
-		when(customFieldsAdapter.selectCustomFields(eq(someMap))).thenReturn(MDC_PROPERTIES);
+		when(event.getMDCPropertyMap()).thenReturn(MDC_PROPERTIES);
 		converter.start();
 
 		CustomField customField = customField("some key", "some value");

--- a/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logging/common/AbstractTest.java
+++ b/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logging/common/AbstractTest.java
@@ -1,5 +1,7 @@
 package com.sap.hcp.cf.logging.common;
 
+import static com.sap.hcp.cf.logging.common.converter.UnmarshallUtilities.unmarshalCustomFields;
+
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.List;
@@ -13,24 +15,35 @@ import com.fasterxml.jackson.jr.ob.JSON;
 public abstract class AbstractTest {
 
     public static final String TEST_MESSAGE = "this is a test message";
+	// see logback-test.xml for valid field keys
+	public static final String CUSTOM_FIELD_KEY = "custom-field";
+	public static final int CUSTOM_FIELD_INDEX = 0;
+	public static final String TEST_FIELD_KEY = "test-field";
+	public static final int TEST_FIELD_INDEX = 1;
+	public static final String RETAINED_FIELD_KEY = "retained-field";
+	public static final int RETAINED_FIELD_INDEX = 2;
     public static final String SOME_KEY = "some_key";
     public static final String SOME_VALUE = "some value";
-    public static final String SOME_OTHER_KEY = "some_other_key";
     public static final String SOME_OTHER_VALUE = "some other value";
+	public static final String HACK_ATTEMPT = "}{:\",\"";
 
     protected final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
     protected final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+	private PrintStream stdout;
+	private PrintStream stderr;
 
     @Before
     public void setupStreams() {
-        System.setOut(new PrintStream(outContent));
+		stdout = System.out;
+		stderr = System.err;
+		System.setOut(new PrintStream(outContent));
         System.setErr(new PrintStream(errContent));
     }
 
     @After
     public void teardownStreams() {
-        System.setOut(null);
-        System.setErr(null);
+		System.setOut(stdout);
+		System.setErr(stderr);
     }
 
     protected String getMessage() {
@@ -61,14 +74,16 @@ public abstract class AbstractTest {
         return lines[lines.length - 1];
     }
 
-    protected String getCustomField(String fieldName) {
-        Map<String, Object> cfMap = getMap("custom_fields");
-        Object fObj = cfMap.get(fieldName);
-        if (fObj != null) {
-            return fObj.toString();
-        }
-        return null;
-    }
+	protected Map<String, Object> getCustomField(String fieldName) throws Exception {
+		List<Map<String, Object>> fields = unmarshalCustomFields(outContent.toString(),
+				Fields.CUSTOM_FIELDS);
+		for (Map<String, Object> field : fields) {
+			if (fieldName.equals(field.get("k"))) {
+				return field;
+			}
+		}
+		return null;
+	}
 
     @SuppressWarnings("unchecked")
     protected Map<String, Object> getMap(String fieldName) {

--- a/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logging/common/TestAppLog.java
+++ b/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logging/common/TestAppLog.java
@@ -1,5 +1,6 @@
 package com.sap.hcp.cf.logging.common;
 
+import static com.sap.hcp.cf.logging.common.converter.CustomFieldMatchers.hasCustomField;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -13,6 +14,8 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.slf4j.Marker;
 import org.slf4j.MarkerFactory;
+
+import com.sap.hcp.cf.logging.common.customfields.CustomField;
 
 public class TestAppLog extends AbstractTest {
 
@@ -70,9 +73,51 @@ public class TestAppLog extends AbstractTest {
         assertThat(getField(Fields.WRITTEN_TS), is(notNullValue()));
         assertThat(getField(Fields.WRITTEN_TS), greaterThanOrEqualTo(Long.toString(beforeTS)));
         assertThat(Long.toString(beforeTS), lessThanOrEqualTo(getField(Fields.WRITTEN_TS)));
+		assertThat(getField(SOME_KEY), is(SOME_VALUE));
+		assertThat(getField("testNumeric"), is("200"));
     }
 
     @Test
+	public void testUnregisteredCustomField() {
+		logMsg = "Running testUnregisteredCustomField()";
+		long beforeTS = System.currentTimeMillis() * 1000000;
+		LOGGER.info(logMsg, CustomField.customField(SOME_KEY, SOME_VALUE));
+		assertThat(getMessage(), is(logMsg));
+		assertThat(getField(SOME_KEY), is(SOME_VALUE));
+		assertThat(getField(Fields.COMPONENT_ID), is("-"));
+		assertThat(getField(Fields.COMPONENT_NAME), is("-"));
+		assertThat(getField(Fields.COMPONENT_INSTANCE), is("0"));
+		assertThat(getField(Fields.WRITTEN_TS), is(notNullValue()));
+		assertThat(getField(Fields.WRITTEN_TS), greaterThanOrEqualTo(Long.toString(beforeTS)));
+		assertThat(Long.toString(beforeTS), lessThanOrEqualTo(getField(Fields.WRITTEN_TS)));
+	}
+
+	@Test
+	public void testCustomFieldOverwritesMdc() throws Exception {
+		MDC.put(CUSTOM_FIELD_KEY, SOME_VALUE);
+		MDC.put(RETAINED_FIELD_KEY, SOME_VALUE);
+		MDC.put(SOME_KEY, SOME_VALUE);
+		logMsg = "Running testCustomFieldOverwritesMdc()";
+		long beforeTS = System.currentTimeMillis() * 1000000;
+		LOGGER.info(logMsg, CustomField.customField(CUSTOM_FIELD_KEY, SOME_OTHER_VALUE),
+				CustomField.customField(RETAINED_FIELD_KEY, SOME_OTHER_VALUE),
+				CustomField.customField(SOME_KEY, SOME_OTHER_VALUE));
+		assertThat(getMessage(), is(logMsg));
+		assertThat(getField(Fields.COMPONENT_ID), is("-"));
+		assertThat(getField(Fields.COMPONENT_NAME), is("-"));
+		assertThat(getField(Fields.COMPONENT_INSTANCE), is("0"));
+		assertThat(getField(Fields.WRITTEN_TS), is(notNullValue()));
+		assertThat(getField(Fields.WRITTEN_TS), greaterThanOrEqualTo(Long.toString(beforeTS)));
+		assertThat(Long.toString(beforeTS), lessThanOrEqualTo(getField(Fields.WRITTEN_TS)));
+		assertThat(getCustomField(CUSTOM_FIELD_KEY),
+				hasCustomField(CUSTOM_FIELD_KEY, SOME_OTHER_VALUE, CUSTOM_FIELD_INDEX));
+		assertThat(getCustomField(RETAINED_FIELD_KEY),
+				hasCustomField(RETAINED_FIELD_KEY, SOME_OTHER_VALUE, RETAINED_FIELD_INDEX));
+		assertThat(getField(RETAINED_FIELD_KEY), is(SOME_OTHER_VALUE));
+		assertThat(getField(SOME_KEY), is(SOME_OTHER_VALUE));
+	}
+
+	@Test
     public void testStacktrace() {
         try {
             Double.parseDouble(null);

--- a/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logging/common/TestCustomFields.java
+++ b/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logging/common/TestCustomFields.java
@@ -30,6 +30,14 @@ public class TestCustomFields extends AbstractTest {
 	}
 
 	@Test
+	public void testCustomFieldWithoutRegistration() throws Exception {
+		LOGGER.info(TEST_MESSAGE, customField("ungregistered", SOME_VALUE));
+
+		assertThat(getField("ungregistered"), is(SOME_VALUE));
+		assertThat(getCustomField("unregistered"), is(nullValue()));
+	}
+
+	@Test
 	public void testCustomFieldAsPartOfMessage() throws Exception {
 		String messageWithPattern = TEST_MESSAGE + " {}";
 		String messageWithKeyValue = TEST_MESSAGE + " " + CUSTOM_FIELD_KEY + "=" + SOME_VALUE;

--- a/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logging/common/TestCustomFields.java
+++ b/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logging/common/TestCustomFields.java
@@ -1,10 +1,9 @@
 package com.sap.hcp.cf.logging.common;
 
+import static com.sap.hcp.cf.logging.common.converter.CustomFieldMatchers.hasCustomField;
 import static com.sap.hcp.cf.logging.common.customfields.CustomField.customField;
-import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.text.StringContainsInOrder.stringContainsInOrder;
 import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
@@ -14,101 +13,88 @@ import org.slf4j.MDC;
 
 public class TestCustomFields extends AbstractTest {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(TestCustomFields.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(TestCustomFields.class);
 
-    @Test
-    public void testLogMessage() {
-        LOGGER.info(TEST_MESSAGE);
-        assertThat(getMessage(), is(TEST_MESSAGE));
-    }
+	@Test
+	public void testLogMessage() {
+		LOGGER.info(TEST_MESSAGE);
+		assertThat(getMessage(), is(TEST_MESSAGE));
+	}
 
-    @Test
-    public void testLogMessageWithCustomField() {
-        LOGGER.info(TEST_MESSAGE, customField(SOME_KEY, SOME_VALUE));
+	@Test
+	public void testLogMessageWithCustomField() throws Exception {
+		LOGGER.info(TEST_MESSAGE, customField(CUSTOM_FIELD_KEY, SOME_VALUE));
 
-        assertThat(getMessage(), is(TEST_MESSAGE));
-        assertThat(getCustomField(SOME_KEY), is(SOME_VALUE));
-    }
+		assertThat(getMessage(), is(TEST_MESSAGE));
+		assertThat(getCustomField(CUSTOM_FIELD_KEY), hasCustomField(CUSTOM_FIELD_KEY, SOME_VALUE, CUSTOM_FIELD_INDEX));
+	}
 
-    @Test
-    public void testCustomFieldAsPartOfMessage() {
-        String messageWithPattern = TEST_MESSAGE + " {}";
-        String messageWithKeyValue = TEST_MESSAGE + " " + SOME_KEY + "=" + SOME_VALUE;
+	@Test
+	public void testCustomFieldAsPartOfMessage() throws Exception {
+		String messageWithPattern = TEST_MESSAGE + " {}";
+		String messageWithKeyValue = TEST_MESSAGE + " " + CUSTOM_FIELD_KEY + "=" + SOME_VALUE;
 
-        LOGGER.info(messageWithPattern, customField(SOME_KEY, SOME_VALUE));
+		LOGGER.info(messageWithPattern, customField(CUSTOM_FIELD_KEY, SOME_VALUE));
 
-        assertThat(getMessage(), is(messageWithKeyValue));
-        assertThat(getCustomField(SOME_KEY), is(SOME_VALUE));
-    }
+		assertThat(getMessage(), is(messageWithKeyValue));
+		assertThat(getCustomField(CUSTOM_FIELD_KEY), hasCustomField(CUSTOM_FIELD_KEY, SOME_VALUE, CUSTOM_FIELD_INDEX));
+	}
 
-    @Test
-    public void testEscape() {
-        String messageWithPattern = TEST_MESSAGE + " {}";
-        String strangeCharacters = "}{:\",\"";
-        String messageWithKeyValue = TEST_MESSAGE + " " + SOME_KEY + "=" + strangeCharacters;
+	@Test
+	public void testEscape() throws Exception {
+		String messageWithPattern = TEST_MESSAGE + " {}";
+		String messageWithKeyValue = TEST_MESSAGE + " " + CUSTOM_FIELD_KEY + "=" + HACK_ATTEMPT;
 
-        LOGGER.info(messageWithPattern, customField(SOME_KEY, strangeCharacters));
+		LOGGER.info(messageWithPattern, customField(CUSTOM_FIELD_KEY, HACK_ATTEMPT));
 
-        assertThat(getMessage(), is(messageWithKeyValue));
-        assertThat(getCustomField(SOME_KEY), is(strangeCharacters));
-    }
+		assertThat(getMessage(), is(messageWithKeyValue));
+		assertThat(getCustomField(CUSTOM_FIELD_KEY),
+				hasCustomField(CUSTOM_FIELD_KEY, HACK_ATTEMPT, CUSTOM_FIELD_INDEX));
+	}
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testNullKey() {
-        customField(null, SOME_VALUE);
-    }
+	@Test(expected = IllegalArgumentException.class)
+	public void testNullKey() {
+		customField(null, SOME_VALUE);
+	}
 
-    @Test
-    public void testNullValue() {
-        LOGGER.info(TEST_MESSAGE, customField(SOME_KEY, null));
+	@Test
+	public void testNullValue() throws Exception {
+		LOGGER.info(TEST_MESSAGE, customField(CUSTOM_FIELD_KEY, null));
 
-        assertThat(getMessage(), is(TEST_MESSAGE));
-        assertThat(getCustomField(SOME_KEY), is("null"));
-    }
+		assertThat(getMessage(), is(TEST_MESSAGE));
+		assertThat(getCustomField(CUSTOM_FIELD_KEY), hasCustomField(CUSTOM_FIELD_KEY, "null", CUSTOM_FIELD_INDEX));
+	}
 
-    @Test
-    public void testLogMessageWithTwoCustomFields() {
-        LOGGER.info(TEST_MESSAGE, customField(SOME_KEY, SOME_VALUE), customField(SOME_OTHER_KEY, SOME_OTHER_VALUE));
+	@Test
+	public void testLogMessageWithTwoCustomFields() throws Exception {
+		LOGGER.info(TEST_MESSAGE, customField(TEST_FIELD_KEY, SOME_VALUE),
+				customField(CUSTOM_FIELD_KEY, SOME_OTHER_VALUE));
 
-        assertThat(getMessage(), is(TEST_MESSAGE));
+		assertThat(getMessage(), is(TEST_MESSAGE));
 
-        assertThat(getCustomField(SOME_KEY), is(SOME_VALUE));
-        assertThat(getCustomField(SOME_OTHER_KEY), is(SOME_OTHER_VALUE));
-    }
-
-    @Test
-    public void testOrderOfLogMessageWithTwoCustomFields() {
-        LOGGER.info(TEST_MESSAGE, customField(SOME_KEY, SOME_VALUE), customField(SOME_OTHER_KEY, SOME_OTHER_VALUE));
-
-        String jsonString = getCustomFields();
-        assertThat(jsonString, stringContainsInOrder(asList(SOME_KEY, SOME_OTHER_KEY)));
-        assertThat(jsonString, stringContainsInOrder(asList(SOME_VALUE, SOME_OTHER_VALUE)));
-    }
-
-    private String getCustomFields() {
-        return getField("custom_fields");
-    }
+		assertThat(getCustomField(TEST_FIELD_KEY), hasCustomField(TEST_FIELD_KEY, SOME_VALUE, TEST_FIELD_INDEX));
+		assertThat(getCustomField(CUSTOM_FIELD_KEY),
+				hasCustomField(CUSTOM_FIELD_KEY, SOME_OTHER_VALUE, CUSTOM_FIELD_INDEX));
+	}
 
 	@Test
 	public void testCustomFieldFromMdcWithoutRetention() throws Exception {
-		// see logback-test.xml for valid field keys
-		MDC.put("test-field", "test-value");
+		MDC.put(TEST_FIELD_KEY, SOME_VALUE);
 
 		LOGGER.info(TEST_MESSAGE);
 
-		assertThat(getCustomField("test-field"), is("test-value"));
-		assertThat(getField("test-field"), is(nullValue()));
+		assertThat(getCustomField(TEST_FIELD_KEY), hasCustomField(TEST_FIELD_KEY, SOME_VALUE, TEST_FIELD_INDEX));
+		assertThat(getField(TEST_FIELD_KEY), is(nullValue()));
 	}
 
 	@Test
 	public void testCustomFieldFromMdcWithRetention() throws Exception {
-		// see logback-test.xml for valid field keys
-		MDC.put("retained-field", "test-value");
+		MDC.put(RETAINED_FIELD_KEY, SOME_VALUE);
 
 		LOGGER.info(TEST_MESSAGE);
 
-		assertThat(getCustomField("retained-field"), is("test-value"));
-		assertThat(getField("retained-field"), is("test-value"));
+		assertThat(getCustomField(RETAINED_FIELD_KEY),
+				hasCustomField(RETAINED_FIELD_KEY, SOME_VALUE, RETAINED_FIELD_INDEX));
+		assertThat(getField(RETAINED_FIELD_KEY), is(SOME_VALUE));
 	}
-
 }


### PR DESCRIPTION
The JSON format for log messages was changed. Custom Fields to be indexed
by SAP CloudPlatform CloudFoundry need to be provided in a different schema.
This PR provides the implementation of the new schema. The Java interface
remains compatible to the current API. There is an additional requirement to the
configuration: `CustomFields` provided as parameters to log functions need to
be declared in the configuration file in the same way that MDC fields needed to 
be declared.