### PR TITLE
Dynamic Log Level configuration for specific Packages

### DIFF
--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/helper/DynamicLogLevelHelper.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/helper/DynamicLogLevelHelper.java
@@ -7,5 +7,6 @@ public class DynamicLogLevelHelper {
      * from mdc
      */
     public static final String MDC_DYNAMIC_LOG_LEVEL_KEY = "dynamic_log_level";
+	public static final String MDC_DYNAMIC_LOG_LEVEL_PREFIXES = "dynamic_log_level_prefixes";
 
 }

--- a/cf-java-logging-support-log4j2/src/main/java/com/sap/hcp/cf/log4j2/filter/DynamicLevelPrefixLoggerFilter.java
+++ b/cf-java-logging-support-log4j2/src/main/java/com/sap/hcp/cf/log4j2/filter/DynamicLevelPrefixLoggerFilter.java
@@ -1,0 +1,95 @@
+package com.sap.hcp.cf.log4j2.filter;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+import org.apache.logging.log4j.core.filter.AbstractFilter;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.util.ReadOnlyStringMap;
+import org.slf4j.MDC;
+
+import com.sap.hcp.cf.logging.common.helper.DynamicLogLevelHelper;
+
+@Plugin(name = "DynamicLevelPrefixLoggerFilter", category = "Core", elementType = "filter", printObject = true)
+public class DynamicLevelPrefixLoggerFilter extends AbstractFilter {
+
+	@Override
+	public Result filter(LogEvent event) {
+		Level level = event.getLevel();
+		Level dynamicLevel = getDynamicLevel(event);
+		String loggerFqcn = event.getLoggerFqcn();
+		String logLevelPackages = getDynamicPackages(event);
+		return filter(level, dynamicLevel, loggerFqcn, logLevelPackages);
+	}
+
+	private Level getDynamicLevel(LogEvent event) {
+		String logLevel = getContextValue(event, DynamicLogLevelHelper.MDC_DYNAMIC_LOG_LEVEL_KEY);
+		return StringUtils.isNotBlank(logLevel) ? Level.getLevel(logLevel) : null;
+	}
+
+	private String getContextValue(LogEvent event, String key) {
+		ReadOnlyStringMap contextData = event.getContextData();
+		return contextData != null ? contextData.getValue(key) : null;
+	}
+
+	private String getDynamicPackages(final LogEvent event) {
+		String logLevelPackages = getContextValue(event, DynamicLogLevelHelper.MDC_DYNAMIC_LOG_LEVEL_PREFIXES);
+		return logLevelPackages;
+	}
+
+	private Result filter(Level level, Level dynamicLevel, String loggerFqcn, String logLevelPackages) {
+		if (dynamicLevel != null && level.isMoreSpecificThan(dynamicLevel)
+				&& checkPackages(loggerFqcn, logLevelPackages)) {
+			return Result.ACCEPT;
+		}
+		return Result.NEUTRAL;
+	}
+
+	private boolean checkPackages(String loggerFqcn, String logLevelPackages) {
+		if (StringUtils.isNotBlank(logLevelPackages)) {
+			for (String current : logLevelPackages.split(",")) {
+				if (loggerFqcn.startsWith(current)) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+
+	@Override
+    public Result filter(final Logger logger, final Level level, final Marker marker, final Message msg,
+                         final Throwable t) {
+		return filter(level, getMdcLevel(), logger.getName(), getMdcPackages());
+    }
+
+	@Override
+	public Result filter(final Logger logger, final Level level, final Marker marker, final Object msg,
+			final Throwable t) {
+		return filter(level, getMdcLevel(), logger.getName(), getMdcPackages());
+	}
+
+	@Override
+	public Result filter(final Logger logger, final Level level, final Marker marker, final String msg,
+			final Object... params) {
+		return filter(level, getMdcLevel(), logger.getName(), getMdcPackages());
+	}
+
+	private Level getMdcLevel() {
+		String mdcLevel = MDC.get(DynamicLogLevelHelper.MDC_DYNAMIC_LOG_LEVEL_KEY);
+		return StringUtils.isNotBlank(mdcLevel) ? Level.getLevel(mdcLevel) : null;
+	}
+
+	private String getMdcPackages() {
+		return MDC.get(DynamicLogLevelHelper.MDC_DYNAMIC_LOG_LEVEL_PREFIXES);
+	}
+
+	@PluginFactory
+	public static DynamicLevelPrefixLoggerFilter createFilter() {
+		return new DynamicLevelPrefixLoggerFilter();
+	}
+}

--- a/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/log4j2/filter/DynamicLevelPrefixLoggerFilterTest.java
+++ b/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/log4j2/filter/DynamicLevelPrefixLoggerFilterTest.java
@@ -1,0 +1,100 @@
+package com.sap.hcp.cf.log4j2.filter;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.net.URL;
+import java.util.HashMap;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.Filter.Result;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.CountingNoOpAppender;
+import org.apache.logging.log4j.core.config.ConfigurationSource;
+import org.apache.logging.log4j.core.config.xml.XmlConfiguration;
+import org.apache.logging.log4j.core.impl.JdkMapAdapterStringMap;
+import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.junit.Test;
+import org.slf4j.MDC;
+
+import com.sap.hcp.cf.logging.common.helper.DynamicLogLevelHelper;
+
+public class DynamicLevelPrefixLoggerFilterTest {
+
+	private static final String KNOWN_PREFIX = "known.prefix";
+	private static final String UNKNOWN_PREFIX = "unknown.prefix";
+
+	private final JdkMapAdapterStringMap contextData;
+	private final DynamicLevelPrefixLoggerFilter filter = new DynamicLevelPrefixLoggerFilter();
+
+	public DynamicLevelPrefixLoggerFilterTest() {
+		HashMap<String, String> customMDC = new HashMap<>();
+		customMDC.put(DynamicLogLevelHelper.MDC_DYNAMIC_LOG_LEVEL_KEY, "DEBUG");
+		customMDC.put(DynamicLogLevelHelper.MDC_DYNAMIC_LOG_LEVEL_PREFIXES, KNOWN_PREFIX);
+		this.contextData = new JdkMapAdapterStringMap(customMDC);
+	}
+
+	@Test
+	public void acceptsOnKnownPackage() throws Exception {
+		Log4jLogEvent event = Log4jLogEvent.newBuilder().setLoggerFqcn(KNOWN_PREFIX + "acceptsOnKnownPackage")
+				.setContextData(contextData).setLevel(Level.INFO).build();
+		assertThat(filter.filter(event), is(Result.ACCEPT));
+	}
+
+	@Test
+	public void neutralOnUnknownPackage() throws Exception {
+		Log4jLogEvent event = Log4jLogEvent.newBuilder().setLoggerFqcn(UNKNOWN_PREFIX + "neutralOnUnknownPackage")
+				.setContextData(contextData).setLevel(Level.INFO).build();
+		assertThat(filter.filter(event), is(Result.NEUTRAL));
+	}
+
+	@Test
+	public void neutralOnLowerLevel() throws Exception {
+		Log4jLogEvent event = Log4jLogEvent.newBuilder().setLoggerFqcn(KNOWN_PREFIX + "neutralOnUnknownPackage")
+				.setContextData(contextData).setLevel(Level.TRACE).build();
+		assertThat(filter.filter(event), is(Result.NEUTRAL));
+	}
+
+	@Test
+	public void neutralOnUnconfiguredLevelKey() throws Exception {
+		HashMap<String, String> customMDC = new HashMap<>();
+		customMDC.put(DynamicLogLevelHelper.MDC_DYNAMIC_LOG_LEVEL_PREFIXES, KNOWN_PREFIX);
+		JdkMapAdapterStringMap missingLevelKey = new JdkMapAdapterStringMap(customMDC);
+		Log4jLogEvent event = Log4jLogEvent.newBuilder().setLoggerFqcn(KNOWN_PREFIX + "neutralOnUnknownPackage")
+				.setContextData(missingLevelKey).setLevel(Level.INFO).build();
+		assertThat(filter.filter(event), is(Result.NEUTRAL));
+	}
+
+	@Test
+	public void neutralOnUnconfiguredPrefix() throws Exception {
+		HashMap<String, String> customMDC = new HashMap<>();
+		customMDC.put(DynamicLogLevelHelper.MDC_DYNAMIC_LOG_LEVEL_PREFIXES, KNOWN_PREFIX);
+		JdkMapAdapterStringMap missingPrefixes = new JdkMapAdapterStringMap(customMDC);
+		Log4jLogEvent event = Log4jLogEvent.newBuilder().setLoggerFqcn(KNOWN_PREFIX + "neutralOnUnknownPackage")
+				.setContextData(missingPrefixes).setLevel(Level.INFO).build();
+		assertThat(filter.filter(event), is(Result.NEUTRAL));
+	}
+
+	@Test
+	public void integratesIntoConfiguration() throws Exception {
+
+		LoggerContext loggerContext = new LoggerContext("integratesIntoConfiguration");
+		URL configLocation = getClass().getResource("log4j2-test.xml");
+		ConfigurationSource configurationSource = ConfigurationSource.fromUri(configLocation.toURI());
+		XmlConfiguration configuration = new XmlConfiguration(loggerContext, configurationSource);
+		loggerContext.start(configuration);
+		org.apache.logging.log4j.core.Logger logger = loggerContext
+				.getLogger(KNOWN_PREFIX + "integratesIntoConfiguration");
+		CountingNoOpAppender appender = new CountingNoOpAppender("integratesIntoConfiguration", null);
+		logger.addAppender(appender);
+		logger.debug("test-integration-message-at-debug");
+		assertThat(appender.getCount(), is(0L));
+		logger.info("test-integration-message-at-info");
+		assertThat(appender.getCount(), is(1L));
+		MDC.put(DynamicLogLevelHelper.MDC_DYNAMIC_LOG_LEVEL_KEY, "DEBUG");
+		MDC.put(DynamicLogLevelHelper.MDC_DYNAMIC_LOG_LEVEL_PREFIXES, KNOWN_PREFIX);
+		logger.debug("test-integration-message-at-debug");
+		assertThat(appender.getCount(), is(2L));
+		loggerContext.close();
+	}
+}

--- a/cf-java-logging-support-log4j2/src/test/resources/com/sap/hcp/cf/log4j2/filter/log4j2-test.xml
+++ b/cf-java-logging-support-log4j2/src/test/resources/com/sap/hcp/cf/log4j2/filter/log4j2-test.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="warn" strict="true"
+	packages="com.sap.hcp.cf.log4j2.converter,com.sap.hcp.cf.log4j2">
+	<DynamicLevelPrefixLoggerFilter />
+	<Appenders>
+		<Console name="Console" target="SYSTEM_OUT">
+			<PatternLayout
+				pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />			
+		</Console>
+	</Appenders>
+	<Loggers>
+		<Root level="info">
+			<AppenderRef ref="Console" />
+		</Root>
+	</Loggers>
+</Configuration>      

--- a/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/filter/DynamicLevelPrefixLoggerTurboFilter.java
+++ b/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/filter/DynamicLevelPrefixLoggerTurboFilter.java
@@ -1,0 +1,38 @@
+package com.sap.hcp.cf.logback.filter;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.MDC;
+import org.slf4j.Marker;
+
+import com.sap.hcp.cf.logging.common.helper.DynamicLogLevelHelper;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.turbo.TurboFilter;
+import ch.qos.logback.core.spi.FilterReply;
+
+public class DynamicLevelPrefixLoggerTurboFilter extends TurboFilter {
+
+	@Override
+	public FilterReply decide(final Marker marker, final Logger logger, final Level level, final String format,
+			final Object[] params, final Throwable t) {
+		final String logLevel = MDC.get(DynamicLogLevelHelper.MDC_DYNAMIC_LOG_LEVEL_KEY);
+		if (logLevel != null && level.isGreaterOrEqual(Level.toLevel(logLevel)) && checkPackages(logger)) {
+			return FilterReply.ACCEPT;
+		}
+		return FilterReply.NEUTRAL;
+	}
+
+	private boolean checkPackages(final Logger logger) {
+		final String logLevelPackages = MDC.get(DynamicLogLevelHelper.MDC_DYNAMIC_LOG_LEVEL_PREFIXES);
+		if (StringUtils.isNotBlank(logLevelPackages)) {
+			for (String current : logLevelPackages.split(",")) {
+				if (logger.getName().startsWith(current)) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+}

--- a/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logback/filter/DynamicLevelPrefixLoggerTurboFilterTest.java
+++ b/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logback/filter/DynamicLevelPrefixLoggerTurboFilterTest.java
@@ -1,0 +1,81 @@
+package com.sap.hcp.cf.logback.filter;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.MDC;
+
+import com.sap.hcp.cf.logging.common.helper.DynamicLogLevelHelper;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.turbo.TurboFilter;
+import ch.qos.logback.core.read.ListAppender;
+import ch.qos.logback.core.spi.FilterReply;
+
+public class DynamicLevelPrefixLoggerTurboFilterTest {
+
+	private static final String KNOWN_PREFIX = "known.prefix";
+	private static final String UNKNOWN_PREFIX = "unknown.prefix";
+
+	private LoggerContext loggerContext = new LoggerContext();
+	private TurboFilter filter = new DynamicLevelPrefixLoggerTurboFilter();
+
+	@Before
+	public void setUp() {
+		MDC.clear();
+		MDC.put(DynamicLogLevelHelper.MDC_DYNAMIC_LOG_LEVEL_KEY, "DEBUG");
+		MDC.put(DynamicLogLevelHelper.MDC_DYNAMIC_LOG_LEVEL_PREFIXES, KNOWN_PREFIX);
+		loggerContext.addTurboFilter(filter);
+	}
+
+	@Test
+	public void acceptsOnKnownPackage() throws Exception {
+		Logger logger = loggerContext.getLogger(KNOWN_PREFIX + "acceptsOnKnownPackage");
+		assertThat(filter.decide(null, logger, Level.INFO, null, null, null), is(FilterReply.ACCEPT));
+	}
+
+	@Test
+	public void neutralOnUnknownPackage() throws Exception {
+		Logger logger = loggerContext.getLogger(UNKNOWN_PREFIX + "neutralOnUnknownPackage");
+		assertThat(filter.decide(null, logger, Level.INFO, null, null, null), is(FilterReply.NEUTRAL));
+	}
+
+	@Test
+	public void neutralOnLowerLevel() throws Exception {
+		Logger logger = loggerContext.getLogger(KNOWN_PREFIX + "neutralOnUnknownPackage");
+		assertThat(filter.decide(null, logger, Level.TRACE, null, null, null), is(FilterReply.NEUTRAL));
+	}
+
+	@Test
+	public void neutralOnUnconfiguredLevelKey() throws Exception {
+		MDC.remove(DynamicLogLevelHelper.MDC_DYNAMIC_LOG_LEVEL_KEY);
+		Logger logger = loggerContext.getLogger(KNOWN_PREFIX + "neutralOnUnknownPackage");
+		assertThat(filter.decide(null, logger, Level.INFO, null, null, null), is(FilterReply.NEUTRAL));
+	}
+
+	@Test
+	public void neutralOnUnconfiguredPrefix() throws Exception {
+		MDC.remove(DynamicLogLevelHelper.MDC_DYNAMIC_LOG_LEVEL_PREFIXES);
+		Logger logger = loggerContext.getLogger(KNOWN_PREFIX + "neutralOnUnknownPackage");
+		assertThat(filter.decide(null, logger, Level.INFO, null, null, null), is(FilterReply.NEUTRAL));
+	}
+
+	@Test
+	public void integratesIntoConfiguration() throws Exception {
+		Logger logger = loggerContext.getLogger(KNOWN_PREFIX + "integratesIntoConfiguration");
+		ListAppender<ILoggingEvent> appender = new ListAppender<ILoggingEvent>();
+		appender.start();
+		logger.addAppender(appender);
+		logger.info("test-integration-message");
+		assertThat(appender.list, hasSize(1));
+		assertThat(appender.list.get(0).getMessage(), is(equalTo("test-integration-message")));
+		appender.stop();
+	}
+}

--- a/cf-java-logging-support-servlet/src/main/java/com/sap/hcp/cf/logging/servlet/dynlog/DynamicLogLevelProcessor.java
+++ b/cf-java-logging-support-servlet/src/main/java/com/sap/hcp/cf/logging/servlet/dynlog/DynamicLogLevelProcessor.java
@@ -39,8 +39,10 @@ public class DynamicLogLevelProcessor {
             try {
                 DecodedJWT jwt = tokenDecoder.validateAndDecodeToken(logLevelToken);
                 String dynamicLogLevel = jwt.getClaim("level").asString();
+				String packages = jwt.getClaim("packages").asString();
                 if (ALLOWED_DYNAMIC_LOGLEVELS.contains(dynamicLogLevel)) {
                     MDC.put(DynamicLogLevelHelper.MDC_DYNAMIC_LOG_LEVEL_KEY, dynamicLogLevel);
+					MDC.put(DynamicLogLevelHelper.MDC_DYNAMIC_LOG_LEVEL_PREFIXES, packages);
                 } else {
                     throw new DynamicLogLevelException("Dynamic Log-Level [" + dynamicLogLevel +
                                                        "] provided in header is not valid. Allowed Values are " +

--- a/cf-java-logging-support-servlet/src/main/java/com/sap/hcp/cf/logging/servlet/dynlog/TokenCreator.java
+++ b/cf-java-logging-support-servlet/src/main/java/com/sap/hcp/cf/logging/servlet/dynlog/TokenCreator.java
@@ -19,107 +19,112 @@ import javax.xml.bind.DatatypeConverter;
 import org.apache.commons.lang3.StringUtils;
 
 import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTCreator.Builder;
 import com.auth0.jwt.algorithms.Algorithm;
 
 public class TokenCreator {
 
-    private static final List<String> ALLOWED_DYNAMIC_LOGLEVELS = Arrays.asList("TRACE", "DEBUG", "INFO", "WARN",
-                                                                                "ERROR");
+	private static final List<String> ALLOWED_DYNAMIC_LOGLEVELS = Arrays.asList("TRACE", "DEBUG", "INFO", "WARN",
+			"ERROR");
 
-    /**
-     * Run this application locally in order to generate valid dynamic log level
-     * JWT tokens which enable you to change the log level threshold on your
-     * CF-Application for a single thread.
-     */
-    public static void main(String[] args) throws NoSuchAlgorithmException, NoSuchProviderException,
-                                           DynamicLogLevelException, InvalidKeySpecException {
+	/**
+	 * Run this application locally in order to generate valid dynamic log level JWT
+	 * tokens which enable you to change the log level threshold on your
+	 * CF-Application for a single thread.
+	 */
+	public static void main(String[] args) throws NoSuchAlgorithmException, NoSuchProviderException,
+			DynamicLogLevelException, InvalidKeySpecException {
 
-        /*
-         * PLEASE PROVIDE THIS INFORMATION ***********************************
-         */
-        // Replace with email address
-        String issuer = "firstname.lastname@sap.com";
-        // Replace with the log level that should be transmitted via the token
-        // Valid log level thresholds are:
-        // "TRACE", "DEBUG", "INFO", "WARN", "ERROR"
-        String level = "TRACE";
-        // Set a validity period in days
-        long validityPeriodInDays = 2;
-        // If available provide Base64 encoded private key here:
-        String privateKey = "";
-        // If available provide Base64 encoded private key here:
-        String publicKey = "";
-        // (If no keys are provided, new keys will be generated)
-        /*
-         * ********************************************************************
-         */
+		/*
+		 * PLEASE PROVIDE THIS INFORMATION ***********************************
+		 */
+		// Replace with email address
+		String issuer = "firstname.lastname@sap.com";
+		// Replace with the log level that should be transmitted via the token
+		// Valid log level thresholds are:
+		// "TRACE", "DEBUG", "INFO", "WARN", "ERROR"
+		String level = "TRACE";
+		// Replace with the packages that should be transmitted via the token
+		// Multiple packages should be separated by a comma.
+		String packages = "";
+		// Set a validity period in days
+		long validityPeriodInDays = 2;
+		// If available provide Base64 encoded private key here:
+		String privateKey = "";
+		// If available provide Base64 encoded private key here:
+		String publicKey = "";
+		// (If no keys are provided, new keys will be generated)
+		/*
+		 * ********************************************************************
+		 */
 
-        KeyPair keyPair;
+		KeyPair keyPair;
 
-        if (StringUtils.isNotBlank(privateKey)) {
-            keyPair = new KeyPair(publicKeyConverter(publicKey), privateKeyConverter(privateKey));
-        }
+		if (StringUtils.isNotBlank(privateKey)) {
+			keyPair = new KeyPair(publicKeyConverter(publicKey), privateKeyConverter(privateKey));
+		}
 
-        else {
-            KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+		else {
+			KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
 			keyGen.initialize(2048);
-            keyPair = keyGen.generateKeyPair();
-            // keyPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
-        }
-        privateKey = DatatypeConverter.printBase64Binary(keyPair.getPrivate().getEncoded());
-        publicKey = DatatypeConverter.printBase64Binary(keyPair.getPublic().getEncoded());
-        Date issuedAt = new Date();
-        Date expiresAt = new Date(new Date().getTime() + validityPeriodInDays * 86400000);
-        String token = TokenCreator.createToken(keyPair, issuer, issuedAt, expiresAt, level);
+			keyPair = keyGen.generateKeyPair();
+			// keyPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
+		}
+		privateKey = DatatypeConverter.printBase64Binary(keyPair.getPrivate().getEncoded());
+		publicKey = DatatypeConverter.printBase64Binary(keyPair.getPublic().getEncoded());
+		Date issuedAt = new Date();
+		Date expiresAt = new Date(new Date().getTime() + validityPeriodInDays * 86400000);
+		String token = TokenCreator.createToken(keyPair, issuer, issuedAt, expiresAt, level, packages);
 
-        System.out.println("You successfully created a dynamic log level token with log level " + level + "!");
-        System.out.println();
-        System.out.println("Your private key is:");
-        System.out.println(privateKey);
-        System.out.println("Your public key is:");
-        System.out.println(publicKey);
-        System.out.println("Your JWT token with log level " + level + " is:");
-        System.out.println(token);
-        System.out.println();
-        System.out.println("Please copy and save token and keys for later usage. The JWT token can now be written");
-        System.out.println("to an HTTP header in order to change the corresponding request's log level to " + level);
-        System.out.println("For token validation, the public key must be added to the environment of the application.");
-        System.out.println("In order to generate a new token with specific keys, the variables privateKey and publicKey");
-        System.out.println("can be instantiated with these keys");
+		System.out.println("You successfully created a dynamic log level token with log level " + level
+				+ " and packages " + packages + "!");
+		System.out.println();
+		System.out.println("Your private key is:");
+		System.out.println(privateKey);
+		System.out.println("Your public key is:");
+		System.out.println(publicKey);
+		System.out.println("Your JWT token with log level " + level + " is:");
+		System.out.println(token);
+		System.out.println();
+		System.out.println("Please copy and save token and keys for later usage. The JWT token can now be written");
+		System.out.println("to an HTTP header in order to change the corresponding request's log level to " + level);
+		System.out.println("For token validation, the public key must be added to the environment of the application.");
+		System.out
+				.println("In order to generate a new token with specific keys, the variables privateKey and publicKey");
+		System.out.println("can be instantiated with these keys");
 
-    }
+	}
 
-    public static String createToken(KeyPair keyPair, String issuer, Date issuedAt, Date expiresAt, String level)
-                                                                                                                  throws NoSuchAlgorithmException,
-                                                                                                                  NoSuchProviderException,
-                                                                                                                  DynamicLogLevelException {
-        Algorithm rsa256 = Algorithm.RSA256((RSAPublicKey) keyPair.getPublic(), (RSAPrivateKey) keyPair.getPrivate());
-        if (ALLOWED_DYNAMIC_LOGLEVELS.contains(level)) {
-            return JWT.create().withIssuer(issuer).//
-                      withIssuedAt(issuedAt). //
-                      withExpiresAt(expiresAt).//
-                      withClaim("level", level).sign(rsa256);
-        } else {
-            throw new DynamicLogLevelException("Dynamic Log-Level [" + level +
-                                               "] provided in header is not valid. Allowed Values are " +
-                                               ALLOWED_DYNAMIC_LOGLEVELS.toString());
-        }
-    }
+	public static String createToken(KeyPair keyPair, String issuer, Date issuedAt, Date expiresAt, String level,
+			String packages) throws NoSuchAlgorithmException, NoSuchProviderException, DynamicLogLevelException {
+		Algorithm rsa256 = Algorithm.RSA256((RSAPublicKey) keyPair.getPublic(), (RSAPrivateKey) keyPair.getPrivate());
+		if (ALLOWED_DYNAMIC_LOGLEVELS.contains(level)) {
+			Builder builder = JWT.create().withIssuer(issuer).//
+					withIssuedAt(issuedAt). //
+					withExpiresAt(expiresAt).//
+					withClaim("level", level);
+			builder = StringUtils.isNotBlank(packages) ? builder.withClaim("packages", packages) : builder;
+			return builder.withClaim("packages", packages).sign(rsa256);
+		} else {
+			throw new DynamicLogLevelException("Dynamic Log-Level [" + level
+					+ "] provided in header is not valid. Allowed Values are " + ALLOWED_DYNAMIC_LOGLEVELS.toString());
+		}
+	}
 
-    private static RSAPublicKey publicKeyConverter(String pemKey) throws NoSuchAlgorithmException,
-                                                                  InvalidKeySpecException {
-        byte[] keyBytes = DatatypeConverter.parseBase64Binary(pemKey);
-        X509EncodedKeySpec spec = new X509EncodedKeySpec(keyBytes);
-        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
-        return (RSAPublicKey) keyFactory.generatePublic(spec);
-    }
+	private static RSAPublicKey publicKeyConverter(String pemKey)
+			throws NoSuchAlgorithmException, InvalidKeySpecException {
+		byte[] keyBytes = DatatypeConverter.parseBase64Binary(pemKey);
+		X509EncodedKeySpec spec = new X509EncodedKeySpec(keyBytes);
+		KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+		return (RSAPublicKey) keyFactory.generatePublic(spec);
+	}
 
-    private static RSAPrivateKey privateKeyConverter(String pemKey) throws NoSuchAlgorithmException,
-                                                                    InvalidKeySpecException {
-        byte[] keyBytes = DatatypeConverter.parseBase64Binary(pemKey);
-        PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(keyBytes);
-        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
-        return (RSAPrivateKey) keyFactory.generatePrivate(spec);
-    }
+	private static RSAPrivateKey privateKeyConverter(String pemKey)
+			throws NoSuchAlgorithmException, InvalidKeySpecException {
+		byte[] keyBytes = DatatypeConverter.parseBase64Binary(pemKey);
+		PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(keyBytes);
+		KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+		return (RSAPrivateKey) keyFactory.generatePrivate(spec);
+	}
 
 }

--- a/cf-java-logging-support-servlet/src/test/java/com/sap/hcp/cf/logging/servlet/dynlog/DynamicLogLevelProcessorTest.java
+++ b/cf-java-logging-support-servlet/src/test/java/com/sap/hcp/cf/logging/servlet/dynlog/DynamicLogLevelProcessorTest.java
@@ -39,7 +39,7 @@ public class DynamicLogLevelProcessorTest extends Mockito {
         String keyBase64 = DatatypeConverter.printBase64Binary(keyPair.getPublic().getEncoded());
         Date issuedAt = new Date();
         Date expiresAt = new Date(new Date().getTime() + 10000);
-        String token = TokenCreator.createToken(keyPair, "issuer", issuedAt, expiresAt, "TRACE");
+		String token = TokenCreator.createToken(keyPair, "issuer", issuedAt, expiresAt, "TRACE", "myPrefix");
         when(environment.getVariable("DYN_LOG_LEVEL_KEY")).thenReturn(keyBase64);
         when(environment.getVariable("DYN_LOG_HEADER")).thenReturn("SAP-LOG-LEVEL");
         when(httpRequest.getHeader("SAP-LOG-LEVEL")).thenReturn(token);
@@ -62,4 +62,11 @@ public class DynamicLogLevelProcessorTest extends Mockito {
         processor.removeDynamicLogLevelFromMDC();
         assertEquals(null, MDC.get(DynamicLogLevelHelper.MDC_DYNAMIC_LOG_LEVEL_KEY));
     }
+
+	@Test
+	public void testCopyDynamicLogPackagesToMDC() throws Exception {
+		processor.copyDynamicLogLevelToMDC(httpRequest);
+		assertEquals("myPrefix", MDC.get(DynamicLogLevelHelper.MDC_DYNAMIC_LOG_LEVEL_PREFIXES));
+
+	}
 }

--- a/cf-java-logging-support-servlet/src/test/java/com/sap/hcp/cf/logging/servlet/dynlog/TokenDecoderTest.java
+++ b/cf-java-logging-support-servlet/src/test/java/com/sap/hcp/cf/logging/servlet/dynlog/TokenDecoderTest.java
@@ -26,7 +26,7 @@ public class TokenDecoderTest {
         invalidKeyPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
         Date issuedAt = new Date();
         Date expiresAt = new Date(new Date().getTime() + 10000);
-        token = TokenCreator.createToken(validKeyPair, "issuer", issuedAt, expiresAt, "TRACE");
+		token = TokenCreator.createToken(validKeyPair, "issuer", issuedAt, expiresAt, "TRACE", "myPrefix");
     }
 
     @Test
@@ -34,6 +34,7 @@ public class TokenDecoderTest {
         TokenDecoder tokenDecoder = new TokenDecoder((RSAPublicKey) validKeyPair.getPublic());
         DecodedJWT jwt = tokenDecoder.validateAndDecodeToken(token);
         assertEquals(jwt.getClaim("level").asString(), "TRACE");
+		assertEquals(jwt.getClaim("packages").asString(), "myPrefix");
     }
 
     @Test(expected = DynamicLogLevelException.class)


### PR DESCRIPTION
This PR adresses #68.

The dynamic log level feature allows changes of the log level by a JWT token in an HTTP request.
This allows e.g. debug output for a specific request. However, the filtering will allow all log messages
of the provided log level to be emitted. To increase control about which classes will generate log
messages at finer granularity two new filters are provided. They allow a comma-separated list of 
package names, for which the dynamic log level will be applied. The JWT token is extended by a
claim `packages`, that takes the list. 

Extending the existing filters was not an option, since they globally reject all messages not matching
the required log level. In the new approach the statically configured rules on log levels still need to
be applied. The user can therefore choose, which logging filter is to be used.