### PR TITLE
Add delegates to WrappedInputStream

### DIFF
--- a/cf-java-logging-support-servlet/src/main/java/com/sap/hcp/cf/logging/servlet/filter/WrappedInputStream.java
+++ b/cf-java-logging-support-servlet/src/main/java/com/sap/hcp/cf/logging/servlet/filter/WrappedInputStream.java
@@ -1,6 +1,7 @@
 package com.sap.hcp.cf.logging.servlet.filter;
 
 import java.io.IOException;
+import java.io.OutputStream;
 
 import javax.servlet.ServletInputStream;
 
@@ -9,54 +10,100 @@ import javax.servlet.ServletInputStream;
  */
 public class WrappedInputStream extends ServletInputStream {
 
-    private int contentLength = -1;
-    private final ServletInputStream wrappedStream;
+	private int contentLength = -1;
+	private int markContentLength = -1;
+	private final ServletInputStream wrappedStream;
 
-    public int getContentLength() {
-        return contentLength;
-    }
+	public int getContentLength() {
+		return contentLength;
+	}
 
-    protected WrappedInputStream(ServletInputStream out) {
-        wrappedStream = out;
-    }
+	protected WrappedInputStream(ServletInputStream in) {
+		wrappedStream = in;
+	}
 
-    @Override
-    public int read() throws IOException {
-        int c = wrappedStream.read();
+	@Override
+	public int read() throws IOException {
+		int c = wrappedStream.read();
+		if (c != -1) {
+			incrContentLength(1);
+		}
+		return c;
+	}
+
+	@Override
+	public int readLine(byte[] b, int off, int len) throws IOException {
+		int retLen = wrappedStream.readLine(b, off, len);
+		if (retLen != -1) {
+			incrContentLength(retLen);
+		}
+		return retLen;
+	}
+
+	@Override
+	public int read(byte[] b) throws IOException {
+		int len = wrappedStream.read(b);
+		if (len != -1) {
+			incrContentLength(len);
+		}
+		return len;
+	}
+
+	@Override
+	public int read(byte[] b, int off, int len) throws IOException {
+		int c = wrappedStream.read(b, off, len);
         if (c != -1) {
-            incrContentLength(1);
+            incrContentLength(c);
         }
         return c;
-    }
+ 	}
 
-    @Override
-    public int readLine(byte[] b, int off, int len) throws IOException {
-        int retLen = wrappedStream.readLine(b, off, len);
-        if (retLen != -1) {
-            incrContentLength(retLen);
-        }
-        return retLen;
-    }
+	private void incrContentLength(int i) {
+		if (contentLength == -1) {
+			contentLength = i;
+		} else {
+			contentLength += i;
+		}
+	}
 
-    @Override
-    public int read(byte[] b) throws IOException {
-        int len = wrappedStream.read(b);
-        if (len != -1) {
-            incrContentLength(len);
-        }
-        return len;
-    }
+	@Override
+	public long skip(long n) throws IOException {
+		long skipped = wrappedStream.skip(n);
+		incrContentLength(toIntExact(skipped));
+		return skipped;
+	}
 
-    @Override
-    public int read(byte[] b, int off, int len) throws IOException {
-        return wrappedStream.read(b, off, len);
-    }
+	private static int toIntExact(long value) {
+		if ((int) value != value) {
+			throw new ArithmeticException("integer overflow");
+		}
+		return (int) value;
+	}
 
-    private void incrContentLength(int i) {
-        if (contentLength == -1) {
-            contentLength = i;
-        } else {
-            contentLength += i;
-        }
-    }
+	@Override
+	public int available() throws IOException {
+		return wrappedStream.available();
+	}
+
+	@Override
+	public void close() throws IOException {
+		wrappedStream.close();
+	}
+
+	@Override
+	public synchronized void mark(int readAheadLimit) {
+		wrappedStream.mark(readAheadLimit);
+		this.markContentLength = this.contentLength;
+	}
+
+	@Override
+	public synchronized void reset() throws IOException {
+		wrappedStream.reset();
+		this.contentLength = this.markContentLength;
+	}
+
+	@Override
+	public boolean markSupported() {
+		return wrappedStream.markSupported();
+	}
 }

--- a/cf-java-logging-support-servlet/src/test/java/com/sap/hcp/cf/logging/servlet/filter/WrappedInputReaderTest.java
+++ b/cf-java-logging-support-servlet/src/test/java/com/sap/hcp/cf/logging/servlet/filter/WrappedInputReaderTest.java
@@ -1,8 +1,8 @@
 package com.sap.hcp.cf.logging.servlet.filter;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.io.BufferedReader;
 import java.io.IOException;

--- a/cf-java-logging-support-servlet/src/test/java/com/sap/hcp/cf/logging/servlet/filter/WrappedInputStreamTest.java
+++ b/cf-java-logging-support-servlet/src/test/java/com/sap/hcp/cf/logging/servlet/filter/WrappedInputStreamTest.java
@@ -1,0 +1,81 @@
+package com.sap.hcp.cf.logging.servlet.filter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import javax.servlet.ServletInputStream;
+
+import org.junit.Test;
+
+public class WrappedInputStreamTest {
+
+	private static final String MESSAGE = "ABCDEFGH";
+
+	private static WrappedInputStream wrap(String text) {
+		ByteArrayInputStream in = new ByteArrayInputStream(MESSAGE.getBytes(StandardCharsets.UTF_8));
+		return new WrappedInputStream(new ServletInputStream() {
+
+			@Override
+			public int read() throws IOException {
+				return in.read();
+			}
+		});
+	}
+
+	@Test
+	public void unreadInputGivesMinusOne() throws Exception {
+		WrappedInputStream input = wrap(MESSAGE);
+
+		assertThat(input.getContentLength(), is(equalTo(-1)));
+	}
+
+	@Test
+	public void readSingleCharacter() throws Exception {
+		WrappedInputStream input = wrap(MESSAGE);
+
+		int read = input.read();
+
+		assertThat((char) read, is(equalTo('A')));
+		assertThat(input.getContentLength(), is(equalTo(1)));
+	}
+
+	@Test
+	public void readCharacterArray() throws Exception {
+		WrappedInputStream input = wrap(MESSAGE);
+		byte[] cbuf = new byte[3];
+
+		input.read(cbuf);
+
+		assertThat(new String(cbuf), is(equalTo("ABC")));
+		assertThat(input.getContentLength(), is(equalTo(3)));
+	}
+
+	@Test
+	public void readCharacterArrayWithOffset() throws Exception {
+		WrappedInputStream input = wrap(MESSAGE);
+
+		byte[] cbuf = new byte[5];
+		input.read(cbuf, 1, 4);
+
+		byte[] expected = new byte[5];
+		System.arraycopy(MESSAGE.getBytes(StandardCharsets.UTF_8), 0, expected, 1, 4);
+
+		assertThat(cbuf, is(equalTo(expected)));
+		assertThat(input.getContentLength(), is(equalTo(4)));
+	}
+
+	@Test
+	public void skipCharacters() throws Exception {
+		WrappedInputStream input = wrap(MESSAGE);
+
+		long skipped = input.skip(3);
+
+		assertThat(input.getContentLength(), is(equalTo((int) skipped)));
+	}
+
+}


### PR DESCRIPTION
WrappedInputStream now delegates all methods ti ServletInputStream.
Note, that SerlevtInputStream does not support `mark`, so there are no
tests for that feature. Implementation was taken from
WrappedInputReader.