### PR TITLE
Refactor Request-Id Handling

### DIFF
--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/LogContext.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/LogContext.java
@@ -21,7 +21,6 @@ public class LogContext {
             put(Fields.CORRELATION_ID, Defaults.UNKNOWN);
             put(Fields.TENANT_ID, Defaults.UNKNOWN);
             put(Fields.TENANT_SUBDOMAIN, Defaults.UNKNOWN);
-            put(Fields.REQUEST_ID, null);
             put(Fields.COMPONENT_ID, Defaults.UNKNOWN);
             put(Fields.COMPONENT_NAME, Defaults.UNKNOWN);
             put(Fields.COMPONENT_TYPE, Defaults.COMPONENT_TYPE);

--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/request/HttpHeaders.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/request/HttpHeaders.java
@@ -14,7 +14,7 @@ import com.sap.hcp.cf.logging.common.LogContext;
 public enum HttpHeaders implements HttpHeader {
 
 	CONTENT_LENGTH("content-length"), CONTENT_TYPE("content-type"), REFERER("referer"), X_FORWARDED_FOR(
-			"x-forwarded-for"), X_VCAP_REQUEST_ID("x-vcap-request-id"), CORRELATION_ID("X-CorrelationID",
+			"x-forwarded-for"), X_VCAP_REQUEST_ID("x-vcap-request-id", Fields.REQUEST_ID, true), CORRELATION_ID("X-CorrelationID",
 					Fields.CORRELATION_ID, true, X_VCAP_REQUEST_ID), TENANT_ID("tenantid", Fields.TENANT_ID, true);
 
 	private HttpHeaders(String name) {

--- a/cf-java-logging-support-core/src/test/java/com/sap/hcp/cf/logging/common/request/HttpHeadersTest.java
+++ b/cf-java-logging-support-core/src/test/java/com/sap/hcp/cf/logging/common/request/HttpHeadersTest.java
@@ -7,14 +7,20 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
-import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.sap.hcp.cf.logging.common.Defaults;
 import com.sap.hcp.cf.logging.common.Fields;
+import com.sap.hcp.cf.logging.common.LogContext;
 
 public class HttpHeadersTest {
+
+    @Before
+    public void resetLogContext() {
+        LogContext.resetContextFields();
+        HttpHeaders.propagated().stream().map(HttpHeader::getField).forEach(LogContext::remove);
+    }
 
     @Test
     public void hasCorrectNumberOfTypes() throws Exception {

--- a/cf-java-logging-support-core/src/test/java/com/sap/hcp/cf/logging/common/request/HttpHeadersTest.java
+++ b/cf-java-logging-support-core/src/test/java/com/sap/hcp/cf/logging/common/request/HttpHeadersTest.java
@@ -1,12 +1,14 @@
 package com.sap.hcp.cf.logging.common.request;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 
+import org.hamcrest.MatcherAssert;
+import org.junit.Assert;
 import org.junit.Test;
 
 import com.sap.hcp.cf.logging.common.Defaults;
@@ -14,56 +16,63 @@ import com.sap.hcp.cf.logging.common.Fields;
 
 public class HttpHeadersTest {
 
-	@Test
-	public void hasCorrectNumberOfTypes() throws Exception {
-		assertThat(HttpHeaders.values().length, is(equalTo(7)));
-	}
+    @Test
+    public void hasCorrectNumberOfTypes() throws Exception {
+        assertThat(HttpHeaders.values().length, is(equalTo(7)));
+    }
 
-	@Test
-	public void hasCorrectNames() throws Exception {
-		assertThat(HttpHeaders.CONTENT_LENGTH.getName(), is("content-length"));
-		assertThat(HttpHeaders.CONTENT_TYPE.getName(), is("content-type"));
-		assertThat(HttpHeaders.CORRELATION_ID.getName(), is("X-CorrelationID"));
-		assertThat(HttpHeaders.REFERER.getName(), is("referer"));
-		assertThat(HttpHeaders.TENANT_ID.getName(), is("tenantid"));
-		assertThat(HttpHeaders.X_FORWARDED_FOR.getName(), is("x-forwarded-for"));
-		assertThat(HttpHeaders.X_VCAP_REQUEST_ID.getName(), is("x-vcap-request-id"));
-	}
+    @Test
+    public void hasCorrectNames() throws Exception {
+        assertThat(HttpHeaders.CONTENT_LENGTH.getName(), is("content-length"));
+        assertThat(HttpHeaders.CONTENT_TYPE.getName(), is("content-type"));
+        assertThat(HttpHeaders.CORRELATION_ID.getName(), is("X-CorrelationID"));
+        assertThat(HttpHeaders.REFERER.getName(), is("referer"));
+        assertThat(HttpHeaders.TENANT_ID.getName(), is("tenantid"));
+        assertThat(HttpHeaders.X_FORWARDED_FOR.getName(), is("x-forwarded-for"));
+        assertThat(HttpHeaders.X_VCAP_REQUEST_ID.getName(), is("x-vcap-request-id"));
+    }
 
-	@Test
-	public void hasCorrectFields() throws Exception {
-		assertThat(HttpHeaders.CONTENT_LENGTH.getField(), is(nullValue()));
-		assertThat(HttpHeaders.CONTENT_TYPE.getField(), is(nullValue()));
-		assertThat(HttpHeaders.CORRELATION_ID.getField(), is(Fields.CORRELATION_ID));
-		assertThat(HttpHeaders.REFERER.getField(), is(nullValue()));
-		assertThat(HttpHeaders.TENANT_ID.getField(), is(Fields.TENANT_ID));
-		assertThat(HttpHeaders.X_FORWARDED_FOR.getField(), is(nullValue()));
-		assertThat(HttpHeaders.X_VCAP_REQUEST_ID.getField(), is(nullValue()));
-	}
+    @Test
+    public void hasCorrectFields() throws Exception {
+        assertThat(HttpHeaders.CONTENT_LENGTH.getField(), is(nullValue()));
+        assertThat(HttpHeaders.CONTENT_TYPE.getField(), is(nullValue()));
+        assertThat(HttpHeaders.CORRELATION_ID.getField(), is(Fields.CORRELATION_ID));
+        assertThat(HttpHeaders.REFERER.getField(), is(nullValue()));
+        assertThat(HttpHeaders.TENANT_ID.getField(), is(Fields.TENANT_ID));
+        assertThat(HttpHeaders.X_FORWARDED_FOR.getField(), is(nullValue()));
+        assertThat(HttpHeaders.X_VCAP_REQUEST_ID.getField(), is(Fields.REQUEST_ID));
+    }
 
-	@Test
-	public void defaultFieldValueIsUnknownWithoutConfiguredField() throws Exception {
-		assertThat(HttpHeaders.CONTENT_LENGTH.getFieldValue(), is(Defaults.UNKNOWN));
-		assertThat(HttpHeaders.CONTENT_TYPE.getFieldValue(), is(Defaults.UNKNOWN));
-		assertThat(HttpHeaders.REFERER.getFieldValue(), is(Defaults.UNKNOWN));
-		assertThat(HttpHeaders.X_FORWARDED_FOR.getFieldValue(), is(Defaults.UNKNOWN));
-		assertThat(HttpHeaders.X_VCAP_REQUEST_ID.getFieldValue(), is(Defaults.UNKNOWN));
-	}
+    @Test
+    public void defaultFieldValueIsUnknownWithoutConfiguredField() throws Exception {
+        assertThat(HttpHeaders.CONTENT_LENGTH.getFieldValue(), is(Defaults.UNKNOWN));
+        assertThat(HttpHeaders.CONTENT_TYPE.getFieldValue(), is(Defaults.UNKNOWN));
+        assertThat(HttpHeaders.REFERER.getFieldValue(), is(Defaults.UNKNOWN));
+        assertThat(HttpHeaders.X_FORWARDED_FOR.getFieldValue(), is(Defaults.UNKNOWN));
+    }
 
-	@Test
-	public void hasCorrectAliases() throws Exception {
-		assertThat(HttpHeaders.CONTENT_LENGTH.getAliases(), is(empty()));
-		assertThat(HttpHeaders.CONTENT_TYPE.getAliases(), is(empty()));
-		assertThat(HttpHeaders.CORRELATION_ID.getAliases(), containsInAnyOrder(HttpHeaders.X_VCAP_REQUEST_ID));
-		assertThat(HttpHeaders.REFERER.getAliases(), is(empty()));
-		assertThat(HttpHeaders.TENANT_ID.getAliases(), is(empty()));
-		assertThat(HttpHeaders.X_FORWARDED_FOR.getAliases(), is(empty()));
-		assertThat(HttpHeaders.X_VCAP_REQUEST_ID.getAliases(), is(empty()));
-	}
+    @Test
+    public void defaultFieldValueIsNullForProgatedHeaders() throws Exception {
+        for (HttpHeader header: HttpHeaders.propagated()) {
+            assertThat("Default of field <" + header.getField() + "> from header <" + header.getName() +
+                       "> should be null", header.getFieldValue(), is(nullValue()));
+        }
+    }
 
-	@Test
-	public void propagatesCorrectHeaders() throws Exception {
-		assertThat(HttpHeaders.propagated(), containsInAnyOrder(HttpHeaders.CORRELATION_ID, HttpHeaders.TENANT_ID));
-	}
+    @Test
+    public void hasCorrectAliases() throws Exception {
+        assertThat(HttpHeaders.CONTENT_LENGTH.getAliases(), is(empty()));
+        assertThat(HttpHeaders.CONTENT_TYPE.getAliases(), is(empty()));
+        assertThat(HttpHeaders.CORRELATION_ID.getAliases(), containsInAnyOrder(HttpHeaders.X_VCAP_REQUEST_ID));
+        assertThat(HttpHeaders.REFERER.getAliases(), is(empty()));
+        assertThat(HttpHeaders.TENANT_ID.getAliases(), is(empty()));
+        assertThat(HttpHeaders.X_FORWARDED_FOR.getAliases(), is(empty()));
+        assertThat(HttpHeaders.X_VCAP_REQUEST_ID.getAliases(), is(empty()));
+    }
+
+    @Test
+    public void propagatesCorrectHeaders() throws Exception {
+        assertThat(HttpHeaders.propagated(), containsInAnyOrder(HttpHeaders.CORRELATION_ID, HttpHeaders.TENANT_ID, HttpHeaders.X_VCAP_REQUEST_ID));
+    }
 
 }

--- a/cf-java-logging-support-servlet/src/main/java/com/sap/hcp/cf/logging/servlet/filter/RequestLogger.java
+++ b/cf-java-logging-support-servlet/src/main/java/com/sap/hcp/cf/logging/servlet/filter/RequestLogger.java
@@ -42,6 +42,7 @@ public class RequestLogger {
 		requestRecord.stop();
 		addRequestHandlingParameters();
 		generateLog();
+		requestRecord.resetContext();
 	}
 
 	private void addRequestHandlingParameters() {

--- a/cf-java-logging-support-servlet/src/main/java/com/sap/hcp/cf/logging/servlet/filter/RequestLoggingFilter.java
+++ b/cf-java-logging-support-servlet/src/main/java/com/sap/hcp/cf/logging/servlet/filter/RequestLoggingFilter.java
@@ -15,6 +15,7 @@ import org.slf4j.MDC;
 
 import com.sap.hcp.cf.logging.common.LogContext;
 import com.sap.hcp.cf.logging.common.LogOptionalFieldsSettings;
+import com.sap.hcp.cf.logging.common.request.HttpHeader;
 import com.sap.hcp.cf.logging.common.request.HttpHeaders;
 import com.sap.hcp.cf.logging.common.request.RequestRecord;
 import com.sap.hcp.cf.logging.servlet.dynlog.DynLogEnvironment;
@@ -144,10 +145,19 @@ public class RequestLoggingFilter implements Filter {
 			if (dynamicLogLevelProcessor != null) {
 				dynamicLogLevelProcessor.removeDynamicLogLevelFromMDC();
 			}
-			LogContext.resetContextFields();
+			resetLogContext();
 		}
 	}
 
+
+    private void resetLogContext() {
+        for (HttpHeader header : HttpHeaders.propagated()) {
+            LogContext.remove(header.getField());
+        }
+        LogContext.resetContextFields();
+    }
+
+	
 	private void doFilter(FilterChain chain, HttpServletRequest httpRequest, HttpServletResponse httpResponse)
 			throws IOException, ServletException {
 		if (chain != null) {

--- a/cf-java-logging-support-servlet/src/main/java/com/sap/hcp/cf/logging/servlet/filter/RequestRecordFactory.java
+++ b/cf-java-logging-support-servlet/src/main/java/com/sap/hcp/cf/logging/servlet/filter/RequestRecordFactory.java
@@ -28,7 +28,6 @@ public class RequestRecordFactory {
 		RequestRecordBuilder rrb =  requestRecord("[SERVLET]").addTag(Fields.REQUEST, getFullRequestUri(request))
 				.addTag(Fields.METHOD, request.getMethod())
 				.addTag(Fields.PROTOCOL, getValue(request.getProtocol()))
-				.addContextTag(Fields.REQUEST_ID, getHeader(request, HttpHeaders.X_VCAP_REQUEST_ID))
 				.addOptionalTag(isSensitiveConnectionData, Fields.REMOTE_IP, getValue(request.getRemoteAddr()))
 				.addOptionalTag(isSensitiveConnectionData, Fields.REMOTE_HOST, getValue(request.getRemoteHost()))
 				.addOptionalTag(isSensitiveConnectionData, Fields.REMOTE_PORT,
@@ -38,7 +37,7 @@ public class RequestRecordFactory {
 				.addOptionalTag(isLogRemoteUserField, Fields.REMOTE_USER, getValue(request.getRemoteUser()))
 				.addOptionalTag(isLogRefererField, Fields.REFERER, getHeader(request, HttpHeaders.REFERER));
 		for (HttpHeader header : HttpHeaders.propagated()) {
-			rrb.addContextTag(header.getField(), getHeader(request, header));
+			rrb.addContextTag(header.getField(), getHeaderValue(request, header, null));
 		}
 		return rrb.build();
 	}

--- a/cf-java-logging-support-servlet/src/test/java/com/sap/hcp/cf/logging/servlet/filter/RequestLoggingFilterTest.java
+++ b/cf-java-logging-support-servlet/src/test/java/com/sap/hcp/cf/logging/servlet/filter/RequestLoggingFilterTest.java
@@ -1,5 +1,6 @@
 package com.sap.hcp.cf.logging.servlet.filter;
 
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.text.IsEmptyString.isEmptyOrNullString;
@@ -24,6 +25,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -84,10 +86,11 @@ public class RequestLoggingFilterTest {
 	@Test
 	public void testSimple() throws IOException, ServletException {
 		FilterChain mockFilterChain = mock(FilterChain.class);
+		
 		new RequestLoggingFilter().doFilter(mockReq, mockResp, mockFilterChain);
 		assertThat(getField(Fields.REQUEST), is(Defaults.UNKNOWN));
 		assertThat(getField(Fields.CORRELATION_ID), not(isEmptyOrNullString()));
-		assertThat(getField(Fields.REQUEST_ID), is(Defaults.UNKNOWN));
+		assertThat(getField(Fields.REQUEST_ID), is(nullValue()));
 		assertThat(getField(Fields.REMOTE_HOST), is(Defaults.UNKNOWN));
 		assertThat(getField(Fields.COMPONENT_ID), is(Defaults.UNKNOWN));
 		assertThat(getField(Fields.CONTAINER_ID), is(Defaults.UNKNOWN));
@@ -110,7 +113,7 @@ public class RequestLoggingFilterTest {
 		new RequestLoggingFilter().doFilter(mockReq, mockResp, mockFilterChain);
 		assertThat(getField(Fields.REQUEST), is(Defaults.UNKNOWN));
 		assertThat(getField(Fields.CORRELATION_ID), not(isEmptyOrNullString()));
-		assertThat(getField(Fields.REQUEST_ID), is(Defaults.UNKNOWN));
+		assertThat(getField(Fields.REQUEST_ID), is(nullValue()));
 		assertThat(getField(Fields.REMOTE_HOST), is(Defaults.UNKNOWN));
 		assertThat(getField(Fields.COMPONENT_ID), is(Defaults.UNKNOWN));
 		assertThat(getField(Fields.CONTAINER_ID), is(Defaults.UNKNOWN));
@@ -132,7 +135,7 @@ public class RequestLoggingFilterTest {
 		new RequestLoggingFilter().doFilter(mockReq, mockResp, mockFilterChain);
 		assertThat(getField(Fields.REQUEST), is(Defaults.UNKNOWN));
 		assertThat(getField(Fields.CORRELATION_ID), not(isEmptyOrNullString()));
-		assertThat(getField(Fields.REQUEST_ID), is(Defaults.UNKNOWN));
+		assertThat(getField(Fields.REQUEST_ID), is(nullValue()));
 		assertThat(getField(Fields.REMOTE_HOST), is(Defaults.UNKNOWN));
 		assertThat(getField(Fields.COMPONENT_ID), is(Defaults.UNKNOWN));
 		assertThat(getField(Fields.CONTAINER_ID), is(Defaults.UNKNOWN));
@@ -204,6 +207,7 @@ public class RequestLoggingFilterTest {
 		new RequestLoggingFilter().doFilter(mockReq, mockResp, mockFilterChain);
 		assertThat(getField(Fields.CORRELATION_ID), is(CORRELATION_ID));
 		assertThat(getField(Fields.CORRELATION_ID), not(REQUEST_ID));
+		assertThat(getField(Fields.REQUEST_ID), is(REQUEST_ID));
 		assertThat(getField(Fields.TENANT_ID), is(Defaults.UNKNOWN));
 	}
 
@@ -217,7 +221,8 @@ public class RequestLoggingFilterTest {
 	}
 	
 	protected String getField(String fieldName) throws JSONObjectException, IOException {
-		return JSON.std.mapFrom(getLastLine()).get(fieldName).toString();
+		Object fieldValue = JSON.std.mapFrom(getLastLine()).get(fieldName);
+        return fieldValue == null ? null : fieldValue.toString();
 	}
 
 	private String getLastLine() {


### PR DESCRIPTION
Request-Ids were treated specially before. They would be added, when the HTTP header x-vcap-request-id
was found in an HTTP request. The field would not be added, even with a default value ("-") otherwise but
just omitted from the logs. This applied to both application and request logs.

The code was refactored to implement this behaviour for all fields, that are generated from an HTTP header.
This makes support for similar cases much simpler. Note: correlation-ids are still special, as they are generated
if not found.