### PR TITLE
Use static loggers (or on-demand creation by holder)

### DIFF
--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/LogContext.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/LogContext.java
@@ -15,6 +15,8 @@ import org.slf4j.MDC;
 
 public class LogContext {
 
+	private static final Logger LOG = LoggerFactory.getLogger(LogContext.class);
+
     @SuppressWarnings("serial")
     private static Map<String, String> CTX_FIELDS = new HashMap<String, String>() {
         {
@@ -112,14 +114,10 @@ public class LogContext {
         }
     }
 
-    private static class LoggerHolder {
-    	static final Logger LOG = LoggerFactory.getLogger(LoggerHolder.class.getEnclosingClass());
-    }
-
     private static void generateAndSetCorrelationId() {
         String generatedCorrelationId = String.valueOf(UUID.randomUUID());
         setCorrelationId(generatedCorrelationId);
 
-        LoggerHolder.LOG.info("generated new correlation id");
+        LOG.info("generated new correlation id");
     }
 }

--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/LogContext.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/LogContext.java
@@ -112,11 +112,14 @@ public class LogContext {
         }
     }
 
+    private static class LoggerHolder {
+    	static final Logger LOG = LoggerFactory.getLogger(LoggerHolder.class.getEnclosingClass());
+    }
+
     private static void generateAndSetCorrelationId() {
         String generatedCorrelationId = String.valueOf(UUID.randomUUID());
         setCorrelationId(generatedCorrelationId);
 
-        Logger logger = LoggerFactory.getLogger(LogContext.class);
-        logger.info("generated new correlation id");
+        LoggerHolder.LOG.info("generated new correlation id");
     }
 }

--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/LogContext.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/LogContext.java
@@ -15,8 +15,6 @@ import org.slf4j.MDC;
 
 public class LogContext {
 
-	private static final Logger LOG = LoggerFactory.getLogger(LogContext.class);
-
     @SuppressWarnings("serial")
     private static Map<String, String> CTX_FIELDS = new HashMap<String, String>() {
         {
@@ -114,10 +112,14 @@ public class LogContext {
         }
     }
 
+    private static class LoggerHolder {
+        static final Logger LOG = LoggerFactory.getLogger(LoggerHolder.class.getEnclosingClass());
+    }
+
     private static void generateAndSetCorrelationId() {
         String generatedCorrelationId = String.valueOf(UUID.randomUUID());
         setCorrelationId(generatedCorrelationId);
 
-        LOG.info("generated new correlation id");
+        LoggerHolder.LOG.info("generated new correlation id");
     }
 }

--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/VcapEnvReader.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/VcapEnvReader.java
@@ -23,6 +23,8 @@ import com.fasterxml.jackson.jr.ob.JSON;
  */
 public class VcapEnvReader {
 
+	private static final Logger LOG = LoggerFactory.getLogger(VcapEnvReader.class);
+
     public static final String ENV_VCAP_APPLICATION = "VCAP_APPLICATION";
     public static final String ENV_CF_INSTANCE_IP = "CF_INSTANCE_IP";
     public static final String ENV_LANSCAPE_ID = "LANDSCAPE_ID";
@@ -56,10 +58,6 @@ public class VcapEnvReader {
         return result;
     }
 
-    private static class LoggerHolder {
-    	static final Logger LOG = LoggerFactory.getLogger(LoggerHolder.class.getEnclosingClass());
-    }
-
     /**
      * Retrieves Cloud Foundry environment variables and fills tag map
      * accordingly. Also returns the tag keys that have been found in those
@@ -90,7 +88,7 @@ public class VcapEnvReader {
                 addField(tags, envKeys, envMap, CF_ORGANIZATION_ID, Fields.ORGANIZATION_ID);
                 addField(tags, envKeys, envMap, CF_ORGANIZATION_NAME, Fields.ORGANIZATION_NAME);
             } catch (Exception ex) {
-                LoggerHolder.LOG.error("Cannot get infos from environment", ex);
+                LOG.error("Cannot get infos from environment", ex);
                 return;
             }
         }

--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/VcapEnvReader.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/VcapEnvReader.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.jr.ob.JSON;
  */
 public class VcapEnvReader {
 
-	private static final Logger LOG = LoggerFactory.getLogger(VcapEnvReader.class);
+    private static final Logger LOG = LoggerFactory.getLogger(VcapEnvReader.class);
 
     public static final String ENV_VCAP_APPLICATION = "VCAP_APPLICATION";
     public static final String ENV_CF_INSTANCE_IP = "CF_INSTANCE_IP";

--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/VcapEnvReader.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/VcapEnvReader.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.jr.ob.JSON;
@@ -55,6 +56,10 @@ public class VcapEnvReader {
         return result;
     }
 
+    private static class LoggerHolder {
+    	static final Logger LOG = LoggerFactory.getLogger(LoggerHolder.class.getEnclosingClass());
+    }
+
     /**
      * Retrieves Cloud Foundry environment variables and fills tag map
      * accordingly. Also returns the tag keys that have been found in those
@@ -85,7 +90,7 @@ public class VcapEnvReader {
                 addField(tags, envKeys, envMap, CF_ORGANIZATION_ID, Fields.ORGANIZATION_ID);
                 addField(tags, envKeys, envMap, CF_ORGANIZATION_NAME, Fields.ORGANIZATION_NAME);
             } catch (Exception ex) {
-                LoggerFactory.getLogger(VcapEnvReader.class).error("Cannot get infos from environment", ex);
+                LoggerHolder.LOG.error("Cannot get infos from environment", ex);
                 return;
             }
         }

--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/converter/DefaultCustomFieldsConverter.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/converter/DefaultCustomFieldsConverter.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -33,6 +34,10 @@ public class DefaultCustomFieldsConverter {
 		this.customFieldKeyNames = customFieldKeyNames;
 	}
 
+    private static class LoggerHolder {
+    	static final Logger LOG = LoggerFactory.getLogger(LoggerHolder.class.getEnclosingClass());
+    }
+
 	public void convert(StringBuilder appendTo, Map<String, String> mdcPropertiesMap, Object... arguments) {
 		if (customFieldKeyNames.isEmpty()) {
 			return;
@@ -46,7 +51,7 @@ public class DefaultCustomFieldsConverter {
 				finishJson(oc, appendTo);
 			} catch (Exception ex) {
 				/* -- avoids substitute logger warnings on startup -- */
-				LoggerFactory.getLogger(DefaultCustomFieldsConverter.class).error("Conversion failed ", ex);
+				LoggerHolder.LOG.error("Conversion failed ", ex);
 			}
 		}
 	}

--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/converter/DefaultCustomFieldsConverter.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/converter/DefaultCustomFieldsConverter.java
@@ -35,7 +35,7 @@ public class DefaultCustomFieldsConverter {
 	}
 
     private static class LoggerHolder {
-    	static final Logger LOG = LoggerFactory.getLogger(LoggerHolder.class.getEnclosingClass());
+        static final Logger LOG = LoggerFactory.getLogger(LoggerHolder.class.getEnclosingClass());
     }
 
 	public void convert(StringBuilder appendTo, Map<String, String> mdcPropertiesMap, Object... arguments) {

--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/converter/DefaultMessageConverter.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/converter/DefaultMessageConverter.java
@@ -31,7 +31,7 @@ public class DefaultMessageConverter {
     }
 
     private static class LoggerHolder {
-    	static final Logger LOG = LoggerFactory.getLogger(LoggerHolder.class.getEnclosingClass());
+        static final Logger LOG = LoggerFactory.getLogger(LoggerHolder.class.getEnclosingClass());
     }
 
     public void convert(String message, StringBuilder appendTo) {

--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/converter/DefaultMessageConverter.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/converter/DefaultMessageConverter.java
@@ -1,5 +1,6 @@
 package com.sap.hcp.cf.logging.common.converter;
 
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.jr.ob.JSON;
@@ -29,6 +30,10 @@ public class DefaultMessageConverter {
         this.escape = escape;
     }
 
+    private static class LoggerHolder {
+    	static final Logger LOG = LoggerFactory.getLogger(LoggerHolder.class.getEnclosingClass());
+    }
+
     public void convert(String message, StringBuilder appendTo) {
         if (message != null) {
             String result;
@@ -42,7 +47,7 @@ public class DefaultMessageConverter {
                     appendTo.append(JSON.std.asString(result));
                 } catch (Exception ex) {
                     /* -- avoids substitute logger warnings on startup -- */
-                    LoggerFactory.getLogger(DefaultMessageConverter.class).error("Conversion failed ", ex);
+                    LoggerHolder.LOG.error("Conversion failed ", ex);
                     appendTo.append(result);
                 }
             } else {

--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/converter/DefaultPropertiesConverter.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/converter/DefaultPropertiesConverter.java
@@ -32,7 +32,7 @@ public class DefaultPropertiesConverter {
     }
 
     private static class LoggerHolder {
-    	static final Logger LOG = LoggerFactory.getLogger(LoggerHolder.class.getEnclosingClass());
+        static final Logger LOG = LoggerFactory.getLogger(LoggerHolder.class.getEnclosingClass());
     }
 
     public void convert(StringBuilder appendTo, Map<String, String> eventProperties) {

--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/converter/DefaultPropertiesConverter.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/converter/DefaultPropertiesConverter.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
@@ -30,6 +31,10 @@ public class DefaultPropertiesConverter {
         }
     }
 
+    private static class LoggerHolder {
+    	static final Logger LOG = LoggerFactory.getLogger(LoggerHolder.class.getEnclosingClass());
+    }
+
     public void convert(StringBuilder appendTo, Map<String, String> eventProperties) {
         Map<String, String> properties = mergeContextMaps(eventProperties);
         if (properties != null && !properties.isEmpty()) {
@@ -48,7 +53,7 @@ public class DefaultPropertiesConverter {
                 appendTo.append(result.substring(1, result.length() - 1));
             } catch (Exception ex) {
                 /* -- avoids substitute logger warnings on startup -- */
-                LoggerFactory.getLogger(DefaultPropertiesConverter.class).error("Conversion failed ", ex);
+                LoggerHolder.LOG.error("Conversion failed ", ex);
             }
         }
     }

--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/converter/DefaultStacktraceConverter.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/converter/DefaultStacktraceConverter.java
@@ -23,7 +23,7 @@ public class DefaultStacktraceConverter extends StacktraceConverter {
     }
 
     private static class LoggerHolder {
-    	static final Logger LOG = LoggerFactory.getLogger(LoggerHolder.class.getEnclosingClass());
+        static final Logger LOG = LoggerFactory.getLogger(LoggerHolder.class.getEnclosingClass());
     }
 
     @Override

--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/converter/DefaultStacktraceConverter.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/converter/DefaultStacktraceConverter.java
@@ -3,6 +3,7 @@ package com.sap.hcp.cf.logging.common.converter;
 import java.io.PrintWriter;
 import java.util.List;
 
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.jr.ob.JSON;
@@ -19,6 +20,10 @@ public class DefaultStacktraceConverter extends StacktraceConverter {
 
     DefaultStacktraceConverter(int maxSize) {
         this.maxSize = maxSize;
+    }
+
+    private static class LoggerHolder {
+    	static final Logger LOG = LoggerFactory.getLogger(LoggerHolder.class.getEnclosingClass());
     }
 
     @Override
@@ -50,7 +55,7 @@ public class DefaultStacktraceConverter extends StacktraceConverter {
             appendTo.append(ac.end().finish());
         } catch (Exception ex) {
             /* -- avoids substitute logger warnings on startup -- */
-            LoggerFactory.getLogger(DefaultStacktraceConverter.class).error("Conversion failed ", ex);
+            LoggerHolder.LOG.error("Conversion failed ", ex);
         }
     }
 }

--- a/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/converter/CategoriesConverter.java
+++ b/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/converter/CategoriesConverter.java
@@ -3,6 +3,7 @@ package com.sap.hcp.cf.logback.converter;
 import java.io.IOException;
 import java.util.Iterator;
 
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
 
@@ -19,6 +20,8 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
  */
 public class CategoriesConverter extends ClassicConverter {
 
+	private static final Logger LOG = LoggerFactory.getLogger(CategoriesConverter.class);
+			
     public static final String WORD = "categories";
 
     @Override
@@ -39,7 +42,7 @@ public class CategoriesConverter extends ClassicConverter {
             getMarkersRecursively(marker, ac);
             appendTo.append(ac.end().finish());
         } catch (IOException ex) {
-            LoggerFactory.getLogger(CategoriesConverter.class).error("conversion failed", ex);
+            LOG.error("conversion failed", ex);
         }
     }
 

--- a/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/converter/CategoriesConverter.java
+++ b/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/converter/CategoriesConverter.java
@@ -20,8 +20,8 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
  */
 public class CategoriesConverter extends ClassicConverter {
 
-	private static final Logger LOG = LoggerFactory.getLogger(CategoriesConverter.class);
-			
+    private static final Logger LOG = LoggerFactory.getLogger(CategoriesConverter.class);
+
     public static final String WORD = "categories";
 
     @Override

--- a/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/converter/CategoriesConverter.java
+++ b/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/converter/CategoriesConverter.java
@@ -20,8 +20,6 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
  */
 public class CategoriesConverter extends ClassicConverter {
 
-    private static final Logger LOG = LoggerFactory.getLogger(CategoriesConverter.class);
-
     public static final String WORD = "categories";
 
     @Override
@@ -36,13 +34,17 @@ public class CategoriesConverter extends ClassicConverter {
         super.start();
     }
 
+    private static class LoggerHolder {
+        static final Logger LOG = LoggerFactory.getLogger(LoggerHolder.class.getEnclosingClass());
+    }
+
     private void getMarkers(Marker marker, StringBuilder appendTo) {
         try {
             ArrayComposer<JSONComposer<String>> ac = JSON.std.composeString().startArray();
             getMarkersRecursively(marker, ac);
             appendTo.append(ac.end().finish());
         } catch (IOException ex) {
-            LOG.error("conversion failed", ex);
+            LoggerHolder.LOG.error("conversion failed", ex);
         }
     }
 


### PR DESCRIPTION
* Switch to static loggers or on-demand creation by holder pattern.
  Rationale: When (for example) log4j is used, with each logger
  creation, a stack trace is captured. This is putting a measurable
  pressure on applications (Memory, CPU). The VM optimizes away the
  holder after first (implicitly) synchronized access.