### PR TITLE
Remove StringBuilder in Logback TimestampConverter

### DIFF
--- a/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/converter/TimestampConverter.java
+++ b/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/converter/TimestampConverter.java
@@ -16,11 +16,9 @@ public class TimestampConverter extends ClassicConverter {
 
     @Override
     public String convert(ILoggingEvent event) {
-        StringBuilder appendTo = new StringBuilder();
-		Instant now = Instant.now();
-		long timestamp = now.getEpochSecond() * 1_000_000_000L + now.getNano();
-		appendTo.append(timestamp);
-        return appendTo.toString();
+	Instant now = Instant.now();
+	long timestamp = now.getEpochSecond() * 1_000_000_000L + now.getNano();
+	return String.valueOf(timestamp);
     }
 
     @Override

--- a/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/converter/TimestampConverter.java
+++ b/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/converter/TimestampConverter.java
@@ -16,9 +16,9 @@ public class TimestampConverter extends ClassicConverter {
 
     @Override
     public String convert(ILoggingEvent event) {
-	Instant now = Instant.now();
-	long timestamp = now.getEpochSecond() * 1_000_000_000L + now.getNano();
-	return String.valueOf(timestamp);
+        Instant now = Instant.now();
+        long timestamp = now.getEpochSecond() * 1_000_000_000L + now.getNano();
+        return String.valueOf(timestamp);
     }
 
     @Override


### PR DESCRIPTION
Fix for #90

The benchmark done using JMH show performance improvement.
```
	@Benchmark
	public String benchmarkStringBuilder() {
		Instant now = Instant.now();
		long timestamp = now.getEpochSecond() * 1_000_000_000L + now.getNano();

		StringBuilder appendTo = new StringBuilder();
		appendTo.append(timestamp);
		return appendTo.toString();
	}

	@Benchmark
	public String benchmarkString() {
		Instant now = Instant.now();
		long timestamp = now.getEpochSecond() * 1_000_000_000L + now.getNano();

		return String.valueOf(timestamp);
	}
```
Result: 
```
Benchmark                                                           Mode     Cnt   Score   Error   Units
Comparison.benchmarkString                                         thrpt     100   2.130 ± 0.052  ops/ms
Comparison.benchmarkStringBuilder                                  thrpt     100   1.801 ± 0.028  ops/ms
Comparison.benchmarkString                                          avgt     100   0.469 ± 0.011   ms/op
Comparison.benchmarkStringBuilder                                   avgt     100   0.862 ± 0.038   ms/op
Comparison.benchmarkString                                            ss     100   0.591 ± 0.095   ms/op
Comparison.benchmarkStringBuilder                                     ss     100   0.966 ± 0.118   ms/op
```