### PR TITLE
Add deprecation messages to Jersey support classes

### DIFF
--- a/cf-java-logging-support-jersey/src/main/java/com/sap/hcp/cf/logging/jersey/filter/ClientRequestContextAdapter.java
+++ b/cf-java-logging-support-jersey/src/main/java/com/sap/hcp/cf/logging/jersey/filter/ClientRequestContextAdapter.java
@@ -8,6 +8,9 @@ import javax.ws.rs.core.MultivaluedMap;
 import com.sap.hcp.cf.logging.common.request.HttpHeader;
 import com.sap.hcp.cf.logging.common.request.RequestRecord.Direction;
 
+// Jersey support has been deprecated in version 3.4.0 for removal in later versions.
+// Please migrate to cf-java-logging-support-servlet.
+@Deprecated
 public class ClientRequestContextAdapter implements RequestContextAdapter {
 
     public static final String LAYER_NAME = "[JERSEY.CLIENT]";

--- a/cf-java-logging-support-jersey/src/main/java/com/sap/hcp/cf/logging/jersey/filter/ClientRequestUtils.java
+++ b/cf-java-logging-support-jersey/src/main/java/com/sap/hcp/cf/logging/jersey/filter/ClientRequestUtils.java
@@ -6,6 +6,9 @@ import com.sap.hcp.cf.logging.common.LogContext;
 import com.sap.hcp.cf.logging.common.request.HttpHeader;
 import com.sap.hcp.cf.logging.common.request.HttpHeaders;
 
+// Jersey support has been deprecated in version 3.4.0 for removal in later versions.
+// Please migrate to cf-java-logging-support-servlet.
+@Deprecated
 public class ClientRequestUtils {
 
 	public static Invocation.Builder propagate(Invocation.Builder builder, javax.ws.rs.core.HttpHeaders reqHeaders) {

--- a/cf-java-logging-support-jersey/src/main/java/com/sap/hcp/cf/logging/jersey/filter/ClientResponseContextAdapter.java
+++ b/cf-java-logging-support-jersey/src/main/java/com/sap/hcp/cf/logging/jersey/filter/ClientResponseContextAdapter.java
@@ -4,6 +4,9 @@ import javax.ws.rs.client.ClientResponseContext;
 
 import com.sap.hcp.cf.logging.common.request.HttpHeader;
 
+// Jersey support has been deprecated in version 3.4.0 for removal in later versions.
+// Please migrate to cf-java-logging-support-servlet.
+@Deprecated
 public class ClientResponseContextAdapter implements ResponseContextAdapter {
 
 	private final ClientResponseContext ctx;

--- a/cf-java-logging-support-jersey/src/main/java/com/sap/hcp/cf/logging/jersey/filter/ContainerRequestContextAdapter.java
+++ b/cf-java-logging-support-jersey/src/main/java/com/sap/hcp/cf/logging/jersey/filter/ContainerRequestContextAdapter.java
@@ -9,6 +9,9 @@ import javax.ws.rs.core.SecurityContext;
 import com.sap.hcp.cf.logging.common.request.HttpHeader;
 import com.sap.hcp.cf.logging.common.request.RequestRecord.Direction;
 
+// Jersey support has been deprecated in version 3.4.0 for removal in later versions.
+// Please migrate to cf-java-logging-support-servlet.
+@Deprecated
 public class ContainerRequestContextAdapter implements RequestContextAdapter {
 
 	public static final String LAYER_NAME = "[JERSEY.CONTAINER]";

--- a/cf-java-logging-support-jersey/src/main/java/com/sap/hcp/cf/logging/jersey/filter/ContainerResponseContextAdapter.java
+++ b/cf-java-logging-support-jersey/src/main/java/com/sap/hcp/cf/logging/jersey/filter/ContainerResponseContextAdapter.java
@@ -4,6 +4,9 @@ import javax.ws.rs.container.ContainerResponseContext;
 
 import com.sap.hcp.cf.logging.common.request.HttpHeader;
 
+// Jersey support has been deprecated in version 3.4.0 for removal in later versions.
+// Please migrate to cf-java-logging-support-servlet.
+@Deprecated
 public class ContainerResponseContextAdapter implements ResponseContextAdapter {
 
 	private final ContainerResponseContext ctx;

--- a/cf-java-logging-support-jersey/src/main/java/com/sap/hcp/cf/logging/jersey/filter/RequestContextAdapter.java
+++ b/cf-java-logging-support-jersey/src/main/java/com/sap/hcp/cf/logging/jersey/filter/RequestContextAdapter.java
@@ -5,6 +5,9 @@ import java.net.URI;
 import com.sap.hcp.cf.logging.common.request.HttpHeader;
 import com.sap.hcp.cf.logging.common.request.RequestRecord.Direction;
 
+// Jersey support has been deprecated in version 3.4.0 for removal in later versions.
+// Please migrate to cf-java-logging-support-servlet.
+@Deprecated
 public interface RequestContextAdapter {
 
     public String getHeader(String headerName);

--- a/cf-java-logging-support-jersey/src/main/java/com/sap/hcp/cf/logging/jersey/filter/RequestMetricsClientRequestFilter.java
+++ b/cf-java-logging-support-jersey/src/main/java/com/sap/hcp/cf/logging/jersey/filter/RequestMetricsClientRequestFilter.java
@@ -8,6 +8,9 @@ import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;
 import javax.ws.rs.ext.Provider;
 
+// Jersey support has been deprecated in version 3.4.0 for removal in later versions.
+// Please migrate to cf-java-logging-support-servlet.
+@Deprecated
 @Provider
 public class RequestMetricsClientRequestFilter implements ClientRequestFilter {
 

--- a/cf-java-logging-support-jersey/src/main/java/com/sap/hcp/cf/logging/jersey/filter/RequestMetricsClientResponseFilter.java
+++ b/cf-java-logging-support-jersey/src/main/java/com/sap/hcp/cf/logging/jersey/filter/RequestMetricsClientResponseFilter.java
@@ -13,6 +13,9 @@ import org.slf4j.LoggerFactory;
 
 import com.sap.hcp.cf.logging.common.request.RequestRecord;
 
+// Jersey support has been deprecated in version 3.4.0 for removal in later versions.
+// Please migrate to cf-java-logging-support-servlet.
+@Deprecated
 @Provider
 public class RequestMetricsClientResponseFilter implements ClientResponseFilter {
 

--- a/cf-java-logging-support-jersey/src/main/java/com/sap/hcp/cf/logging/jersey/filter/RequestMetricsContainerRequestFilter.java
+++ b/cf-java-logging-support-jersey/src/main/java/com/sap/hcp/cf/logging/jersey/filter/RequestMetricsContainerRequestFilter.java
@@ -9,6 +9,9 @@ import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.PreMatching;
 import javax.ws.rs.ext.Provider;
 
+// Jersey support has been deprecated in version 3.4.0 for removal in later versions.
+// Please migrate to cf-java-logging-support-servlet.
+@Deprecated
 @Provider
 @PreMatching
 public class RequestMetricsContainerRequestFilter implements ContainerRequestFilter {

--- a/cf-java-logging-support-jersey/src/main/java/com/sap/hcp/cf/logging/jersey/filter/RequestMetricsContainerResponseFilter.java
+++ b/cf-java-logging-support-jersey/src/main/java/com/sap/hcp/cf/logging/jersey/filter/RequestMetricsContainerResponseFilter.java
@@ -13,6 +13,9 @@ import org.slf4j.LoggerFactory;
 
 import com.sap.hcp.cf.logging.common.request.RequestRecord;
 
+// Jersey support has been deprecated in version 3.4.0 for removal in later versions.
+// Please migrate to cf-java-logging-support-servlet.
+@Deprecated
 @Provider
 public class RequestMetricsContainerResponseFilter implements ContainerResponseFilter {
 

--- a/cf-java-logging-support-jersey/src/main/java/com/sap/hcp/cf/logging/jersey/filter/RequestMetricsDynamicBinding.java
+++ b/cf-java-logging-support-jersey/src/main/java/com/sap/hcp/cf/logging/jersey/filter/RequestMetricsDynamicBinding.java
@@ -5,6 +5,9 @@ import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.FeatureContext;
 import javax.ws.rs.ext.Provider;
 
+// Jersey support has been deprecated in version 3.4.0 for removal in later versions.
+// Please migrate to cf-java-logging-support-servlet.
+@Deprecated
 @Provider
 public class RequestMetricsDynamicBinding implements DynamicFeature {
 

--- a/cf-java-logging-support-jersey/src/main/java/com/sap/hcp/cf/logging/jersey/filter/RequestMetricsFilterRegistry.java
+++ b/cf-java-logging-support-jersey/src/main/java/com/sap/hcp/cf/logging/jersey/filter/RequestMetricsFilterRegistry.java
@@ -5,6 +5,9 @@ import javax.ws.rs.core.Configurable;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.server.ResourceConfig;
 
+// Jersey support has been deprecated in version 3.4.0 for removal in later versions.
+// Please migrate to cf-java-logging-support-servlet.
+@Deprecated
 public class RequestMetricsFilterRegistry {
 
     public static void registerContainerFilters(Configurable<ResourceConfig> config) {

--- a/cf-java-logging-support-jersey/src/main/java/com/sap/hcp/cf/logging/jersey/filter/ResponseContextAdapter.java
+++ b/cf-java-logging-support-jersey/src/main/java/com/sap/hcp/cf/logging/jersey/filter/ResponseContextAdapter.java
@@ -2,6 +2,9 @@ package com.sap.hcp.cf.logging.jersey.filter;
 
 import com.sap.hcp.cf.logging.common.request.HttpHeader;
 
+// Jersey support has been deprecated in version 3.4.0 for removal in later versions.
+// Please migrate to cf-java-logging-support-servlet.
+@Deprecated
 public interface ResponseContextAdapter {
 
 	public String getHeader(HttpHeader header);

--- a/cf-java-logging-support-jersey/src/main/java/com/sap/hcp/cf/logging/jersey/filter/ResponseHandler.java
+++ b/cf-java-logging-support-jersey/src/main/java/com/sap/hcp/cf/logging/jersey/filter/ResponseHandler.java
@@ -9,6 +9,9 @@ import com.sap.hcp.cf.logging.common.Markers;
 import com.sap.hcp.cf.logging.common.request.HttpHeaders;
 import com.sap.hcp.cf.logging.common.request.RequestRecord;
 
+// Jersey support has been deprecated in version 3.4.0 for removal in later versions.
+// Please migrate to cf-java-logging-support-servlet.
+@Deprecated
 public class ResponseHandler {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(ResponseHandler.class);

--- a/cf-java-logging-support-jersey/src/main/java/com/sap/hcp/cf/logging/jersey/filter/Utils.java
+++ b/cf-java-logging-support-jersey/src/main/java/com/sap/hcp/cf/logging/jersey/filter/Utils.java
@@ -1,5 +1,8 @@
 package com.sap.hcp.cf.logging.jersey.filter;
 
+// Jersey support has been deprecated in version 3.4.0 for removal in later versions.
+// Please migrate to cf-java-logging-support-servlet.
+@Deprecated
 public interface Utils {
     String REQ_METRICS_KEY = "CFRequestMetrics";
 }

--- a/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/perf/PerfTestRequestRecord.java
+++ b/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/perf/PerfTestRequestRecord.java
@@ -12,7 +12,7 @@ import com.sap.hcp.cf.logging.common.request.RequestRecord;
 
 public class PerfTestRequestRecord {
 
-    private static final int DEF_ITERATIONS = 1000000;
+	private static final int DEF_ITERATIONS = 1000000;
 	private final int iterations;
 	private static final Logger LOGGER = LoggerFactory.getLogger(PerfTestRequestRecord.class);
 

--- a/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/perf/PerfTestRequestRecord.java
+++ b/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/perf/PerfTestRequestRecord.java
@@ -12,7 +12,7 @@ import com.sap.hcp.cf.logging.common.request.RequestRecord;
 
 public class PerfTestRequestRecord {
 
-	private static final int DEF_ITERATIONS = 1000000;
+    private static final int DEF_ITERATIONS = 1000000;
 	private final int iterations;
 	private static final Logger LOGGER = LoggerFactory.getLogger(PerfTestRequestRecord.class);
 


### PR DESCRIPTION
Addresses #93 

Support for cf-java-logging-support-jersey will be discontinued in future versions.
This change marks all classes accordingly. It allows developers who use this feature
to get a warning, that they should migrate their code. Additionally they can contact
the library maintainers for advice.