### PR TITLE
Limit travis builds to master branch and PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,4 @@
 language: java
+branches:
+  only:
+  - master


### PR DESCRIPTION
- Limit travis builds to commits on master branch and PRs to master branch. This avoids double builds for PRs.
- PR builds can be enabled/disabled in [travis settings](https://travis-ci.com/github/SAP/cf-java-logging-support/settings).