### PR TITLE
Support for Http Proxy Headers

### DIFF
--- a/cf-java-logging-support-core/beats/request-metrics/docs/fields.asciidoc
+++ b/cf-java-logging-support-core/beats/request-metrics/docs/fields.asciidoc
@@ -703,7 +703,7 @@ example: requested-host.example.com
 
 required: False
 
-The originally reqeusted host by the client in the host HTTP request header.
+The originally requested host by the client in the host HTTP request header.
 A proxy may forward the host header using the x-forwarded-host header.
 
 
@@ -793,7 +793,7 @@ issuer of the client certificate.
 
 type: string
 
-example: /C=FR/ST=Ile de France/L=Jouy en Josas/O=haproxy.com/CN=haproxy.com/emailAddress=ba@haproxy.com
+example: 130613144555Z
 
 required: False
 
@@ -805,7 +805,7 @@ certificate as a formatted string YYMMDDhhmmss.
 
 type: string
 
-example: /C=FR/ST=Ile de France/L=Jouy en Josas/O=haproxy.com/CN=haproxy.com/emailAddress=ba@haproxy.com
+example: 140613144555Z
 
 required: False
 

--- a/cf-java-logging-support-core/beats/request-metrics/docs/fields.asciidoc
+++ b/cf-java-logging-support-core/beats/request-metrics/docs/fields.asciidoc
@@ -727,6 +727,100 @@ example: central-host.example.com
 
 required: False
 
-An header set by a proxy or load balancer for special use-cases.
+A header set by a proxy or load balancer for special use-cases.
+
+
+==== x_ssl_client
+
+type: string
+
+example: 0
+
+required: False
+
+A header set by HA-Proxy to indicate usage of a secured connection by the 
+client (1) or not (0).
+
+
+==== x_ssl_client_verify
+
+type: string
+
+example: 0
+
+required: False
+
+A header set by HA-Proxy to indicate the status code of the TLS/SSL connection.
+
+
+==== x_ssl_client_subject_dn
+
+type: string
+
+example: /C=FR/ST=Ile de France/L=Jouy en Josas/O=haproxy.com/CN=client1/emailAddress=ba@haproxy.com
+
+required: False
+
+A header set by HA-Proxy to provide the full distinguished name of the
+client certificate.
+
+
+==== x_ssl_client_subject_cn
+
+type: string
+
+example: client1
+
+required: False
+
+A header set by HA-Proxy to provide the full common name of the
+client certificate.
+
+
+==== x_ssl_client_issuer_dn
+
+type: string
+
+example: /C=FR/ST=Ile de France/L=Jouy en Josas/O=haproxy.com/CN=haproxy.com/emailAddress=ba@haproxy.com
+
+required: False
+
+A header set by HA-Proxy to provide the full distinguished name of the
+issuer of the client certificate.
+
+
+==== x_ssl_client_notbefore
+
+type: string
+
+example: /C=FR/ST=Ile de France/L=Jouy en Josas/O=haproxy.com/CN=haproxy.com/emailAddress=ba@haproxy.com
+
+required: False
+
+A header set by HA-Proxy to provide the start date of the client
+certificate as a formatted string YYMMDDhhmmss.
+
+
+==== x_ssl_client_notafter
+
+type: string
+
+example: /C=FR/ST=Ile de France/L=Jouy en Josas/O=haproxy.com/CN=haproxy.com/emailAddress=ba@haproxy.com
+
+required: False
+
+A header set by HA-Proxy to provide the end date of the client
+certificate as a formatted string YYMMDDhhmmss.
+
+
+==== x_ssl_client_session_id
+
+type: string
+
+example: session-id
+
+required: False
+
+A header to indicate the SSL client session id.
 
 

--- a/cf-java-logging-support-core/beats/request-metrics/docs/fields.asciidoc
+++ b/cf-java-logging-support-core/beats/request-metrics/docs/fields.asciidoc
@@ -695,3 +695,38 @@ client, followed by proxy server addresses that forwarded the client
 request.
 
 
+==== x_forwarded_host
+
+type: string
+
+example: requested-host.example.com
+
+required: False
+
+The originally reqeusted host by the client in the host HTTP request header.
+A proxy may forward the host header using the x-forwarded-host header.
+
+
+==== x_forwarded_proto
+
+type: string
+
+example: https
+
+required: False
+
+The original protocol used by the client to connect to the proxy or load balancer
+before the application.
+
+
+==== x_custom_host
+
+type: string
+
+example: central-host.example.com
+
+required: False
+
+An header set by a proxy or load balancer for special use-cases.
+
+

--- a/cf-java-logging-support-core/beats/request-metrics/etc/fields.yml
+++ b/cf-java-logging-support-core/beats/request-metrics/etc/fields.yml
@@ -501,3 +501,26 @@ request-metrics:
         Comma-separated list of IP addresses, the left-most being the original
         client, followed by proxy server addresses that forwarded the client
         request.
+
+    - name: "x_forwarded_host"
+      type: string
+      required: false
+      example: "requested-host.example.com"
+      description: |
+        The originally reqeusted host by the client in the host HTTP request header.
+        A proxy may forward the host header using the x-forwarded-host header.
+
+    - name: "x_forwarded_proto"
+      type: string
+      required: false
+      example: "https"
+      description: |
+        The original protocol used by the client to connect to the proxy or load balancer
+        before the application.
+
+    - name: "x_custom_host"
+      type: string
+      required: false
+      example: "central-host.example.com"
+      description: |
+        An header set by a proxy or load balancer for special use-cases.

--- a/cf-java-logging-support-core/beats/request-metrics/etc/fields.yml
+++ b/cf-java-logging-support-core/beats/request-metrics/etc/fields.yml
@@ -523,4 +523,66 @@ request-metrics:
       required: false
       example: "central-host.example.com"
       description: |
-        An header set by a proxy or load balancer for special use-cases.
+        A header set by a proxy or load balancer for special use-cases.
+
+    - name: "x_ssl_client"
+      type: string
+      required: false
+      example: "0"
+      description: |
+        A header set by HA-Proxy to indicate usage of a secured connection by the 
+        client (1) or not (0).
+
+    - name: "x_ssl_client_verify"
+      type: string
+      required: false
+      example: "0"
+      description: |
+        A header set by HA-Proxy to indicate the status code of the TLS/SSL connection.
+
+    - name: "x_ssl_client_subject_dn"
+      type: string
+      required: false
+      example: "/C=FR/ST=Ile de France/L=Jouy en Josas/O=haproxy.com/CN=client1/emailAddress=ba@haproxy.com"
+      description: |
+        A header set by HA-Proxy to provide the full distinguished name of the
+        client certificate.
+
+    - name: "x_ssl_client_subject_cn"
+      type: string
+      required: false
+      example: "client1"
+      description: |
+        A header set by HA-Proxy to provide the full common name of the
+        client certificate.
+
+    - name: "x_ssl_client_issuer_dn"
+      type: string
+      required: false
+      example: "/C=FR/ST=Ile de France/L=Jouy en Josas/O=haproxy.com/CN=haproxy.com/emailAddress=ba@haproxy.com"
+      description: |
+        A header set by HA-Proxy to provide the full distinguished name of the
+        issuer of the client certificate.
+
+    - name: "x_ssl_client_notbefore"
+      type: string
+      required: false
+      example: "/C=FR/ST=Ile de France/L=Jouy en Josas/O=haproxy.com/CN=haproxy.com/emailAddress=ba@haproxy.com"
+      description: |
+        A header set by HA-Proxy to provide the start date of the client
+        certificate as a formatted string YYMMDDhhmmss.
+
+    - name: "x_ssl_client_notafter"
+      type: string
+      required: false
+      example: "/C=FR/ST=Ile de France/L=Jouy en Josas/O=haproxy.com/CN=haproxy.com/emailAddress=ba@haproxy.com"
+      description: |
+        A header set by HA-Proxy to provide the end date of the client
+        certificate as a formatted string YYMMDDhhmmss.
+
+    - name: "x_ssl_client_session_id"
+      type: string
+      required: false
+      example: "session-id"
+      description: |
+        A header to indicate the SSL client session id.

--- a/cf-java-logging-support-core/beats/request-metrics/etc/fields.yml
+++ b/cf-java-logging-support-core/beats/request-metrics/etc/fields.yml
@@ -567,7 +567,7 @@ request-metrics:
     - name: "x_ssl_client_notbefore"
       type: string
       required: false
-      example: "/C=FR/ST=Ile de France/L=Jouy en Josas/O=haproxy.com/CN=haproxy.com/emailAddress=ba@haproxy.com"
+      example: "130613144555Z"
       description: |
         A header set by HA-Proxy to provide the start date of the client
         certificate as a formatted string YYMMDDhhmmss.
@@ -575,7 +575,7 @@ request-metrics:
     - name: "x_ssl_client_notafter"
       type: string
       required: false
-      example: "/C=FR/ST=Ile de France/L=Jouy en Josas/O=haproxy.com/CN=haproxy.com/emailAddress=ba@haproxy.com"
+      example: "140613144555Z"
       description: |
         A header set by HA-Proxy to provide the end date of the client
         certificate as a formatted string YYMMDDhhmmss.

--- a/cf-java-logging-support-core/beats/request-metrics/etc/fields.yml
+++ b/cf-java-logging-support-core/beats/request-metrics/etc/fields.yml
@@ -507,7 +507,7 @@ request-metrics:
       required: false
       example: "requested-host.example.com"
       description: |
-        The originally reqeusted host by the client in the host HTTP request header.
+        The originally requested host by the client in the host HTTP request header.
         A proxy may forward the host header using the x-forwarded-host header.
 
     - name: "x_forwarded_proto"

--- a/cf-java-logging-support-core/beats/request-metrics/etc/request-metrics.template.json
+++ b/cf-java-logging-support-core/beats/request-metrics/etc/request-metrics.template.json
@@ -273,7 +273,22 @@
           "ignore_malformed": true,
           "type": "long"
         },
+        "x_custom_host": {
+          "doc_values": true,
+          "index": "not_analyzed",
+          "type": "string"
+        },
         "x_forwarded_for": {
+          "doc_values": true,
+          "index": "not_analyzed",
+          "type": "string"
+        },
+        "x_forwarded_host": {
+          "doc_values": true,
+          "index": "not_analyzed",
+          "type": "string"
+        },
+        "x_forwarded_proto": {
           "doc_values": true,
           "index": "not_analyzed",
           "type": "string"

--- a/cf-java-logging-support-core/beats/request-metrics/etc/request-metrics.template.json
+++ b/cf-java-logging-support-core/beats/request-metrics/etc/request-metrics.template.json
@@ -292,6 +292,46 @@
           "doc_values": true,
           "index": "not_analyzed",
           "type": "string"
+        },
+        "x_ssl_client": {
+          "doc_values": true,
+          "index": "not_analyzed",
+          "type": "string"
+        },
+        "x_ssl_client_issuer_dn": {
+          "doc_values": true,
+          "index": "not_analyzed",
+          "type": "string"
+        },
+        "x_ssl_client_notafter": {
+          "doc_values": true,
+          "index": "not_analyzed",
+          "type": "string"
+        },
+        "x_ssl_client_notbefore": {
+          "doc_values": true,
+          "index": "not_analyzed",
+          "type": "string"
+        },
+        "x_ssl_client_session_id": {
+          "doc_values": true,
+          "index": "not_analyzed",
+          "type": "string"
+        },
+        "x_ssl_client_subject_cn": {
+          "doc_values": true,
+          "index": "not_analyzed",
+          "type": "string"
+        },
+        "x_ssl_client_subject_dn": {
+          "doc_values": true,
+          "index": "not_analyzed",
+          "type": "string"
+        },
+        "x_ssl_client_verify": {
+          "doc_values": true,
+          "index": "not_analyzed",
+          "type": "string"
         }
       }
     }

--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/Fields.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/Fields.java
@@ -68,4 +68,12 @@ public interface Fields {
   public String X_FORWARDED_HOST = "x_forwarded_host";
   public String X_FORWARDED_PROTO = "x_forwarded_proto";
   public String X_CUSTOM_HOST = "x_custom_host";
+  public String X_SSL_CLIENT = "x_ssl_client";
+  public String X_SSL_CLIENT_VERIFY = "x_ssl_client_verify";
+  public String X_SSL_CLIENT_SUBJECT_DN = "x_ssl_client_subject_dn";
+  public String X_SSL_CLIENT_SUBJECT_CN = "x_ssl_client_subject_cn";
+  public String X_SSL_CLIENT_ISSUER_DN = "x_ssl_client_issuer_dn";
+  public String X_SSL_CLIENT_NOTBEFORE = "x_ssl_client_notbefore";
+  public String X_SSL_CLIENT_NOTAFTER = "x_ssl_client_notafter";
+  public String X_SSL_CLIENT_SESSION_ID = "x_ssl_client_session_id";
 }

--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/Fields.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/Fields.java
@@ -65,4 +65,7 @@ public interface Fields {
   public String RESPONSE_CONTENT_TYPE = "response_content_type";
   public String REFERER = "referer";
   public String X_FORWARDED_FOR = "x_forwarded_for";
+  public String X_FORWARDED_HOST = "x_forwarded_host";
+  public String X_FORWARDED_PROTO = "x_forwarded_proto";
+  public String X_CUSTOM_HOST = "x_custom_host";
 }

--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/LogOptionalFieldsSettings.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/LogOptionalFieldsSettings.java
@@ -12,6 +12,7 @@ public class LogOptionalFieldsSettings {
     private final boolean logSensitiveConnectionData;
     private final boolean logRemoteUserField;
     private final boolean logRefererField;
+    private final boolean logSslHeaders;
 
     public LogOptionalFieldsSettings(String invokingClass) {
         this(new Environment(), invokingClass);
@@ -22,6 +23,7 @@ public class LogOptionalFieldsSettings {
                                                              invokingClass);
         logRemoteUserField = readEnvironmentVariable(Environment.LOG_REMOTE_USER, environment, invokingClass);
         logRefererField = readEnvironmentVariable(Environment.LOG_REFERER, environment, invokingClass);
+        logSslHeaders = readEnvironmentVariable(Environment.LOG_SSL_HEADERS, environment, invokingClass);
     }
 
     private static boolean readEnvironmentVariable(String environmentVariableKey, Environment environment,
@@ -62,5 +64,9 @@ public class LogOptionalFieldsSettings {
 
     public boolean isLogRefererField() {
         return logRefererField;
+    }
+
+    public boolean isLogSslHeaders() {
+        return logSslHeaders;
     }
 }

--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/helper/Environment.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/helper/Environment.java
@@ -5,6 +5,7 @@ public class Environment {
     public static final String LOG_SENSITIVE_CONNECTION_DATA = "LOG_SENSITIVE_CONNECTION_DATA";
     public static final String LOG_REMOTE_USER = "LOG_REMOTE_USER";
     public static final String LOG_REFERER = "LOG_REFERER";
+    public static final String LOG_SSL_HEADERS = "LOG_SSL_HEADERS";
 
     public String getVariable(String name) {
         return System.getenv(name);

--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/request/HttpHeaders.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/request/HttpHeaders.java
@@ -15,10 +15,24 @@ public enum HttpHeaders implements HttpHeader {
                                                CONTENT_LENGTH("content-length"), //
                                                CONTENT_TYPE("content-type"), //
                                                REFERER("referer"), //
-                                               X_CUSTOM_HOST("x-custom-host", Fields.X_CUSTOM_HOST, false), //
-                                               X_FORWARDED_FOR("x-forwarded-for", Fields.X_FORWARDED_FOR, false), //
-                                               X_FORWARDED_HOST("x-forwarded-host", Fields.X_FORWARDED_HOST, false), //
-                                               X_FORWARDED_PROTO("x-forwarded-proto", Fields.X_FORWARDED_PROTO, false), //
+                                               X_CUSTOM_HOST("x-custom-host", Fields.X_CUSTOM_HOST), //
+                                               X_FORWARDED_FOR("x-forwarded-for", Fields.X_FORWARDED_FOR), //
+                                               X_FORWARDED_HOST("x-forwarded-host", Fields.X_FORWARDED_HOST), //
+                                               X_FORWARDED_PROTO("x-forwarded-proto", Fields.X_FORWARDED_PROTO), //
+                                               X_SSL_CLIENT("x-ssl-client", Fields.X_SSL_CLIENT), //
+                                               X_SSL_CLIENT_VERIFY("x-ssl-client-verify", Fields.X_SSL_CLIENT_VERIFY), //
+                                               X_SSL_CLIENT_SUBJECT_DN("x-ssl-client-subject-dn",
+                                                                       Fields.X_SSL_CLIENT_SUBJECT_DN), //
+                                               X_SSL_CLIENT_SUBJECT_CN("x-ssl-client-subject-cn",
+                                                                       Fields.X_SSL_CLIENT_SUBJECT_CN), //
+                                               X_SSL_CLIENT_ISSUER_DN("x-ssl-client-issuer-dn",
+                                                                      Fields.X_SSL_CLIENT_ISSUER_DN), //
+                                               X_SSL_CLIENT_NOTBEFORE("x-ssl-client-notbefore",
+                                                                      Fields.X_SSL_CLIENT_NOTBEFORE), //
+                                               X_SSL_CLIENT_NOTAFTER("x-ssl-client-notafter",
+                                                                     Fields.X_SSL_CLIENT_NOTAFTER), //
+                                               X_SSL_CLIENT_SESSION_ID("x-ssl-client-session-id",
+                                                                       Fields.X_SSL_CLIENT_SESSION_ID), //
                                                X_VCAP_REQUEST_ID("x-vcap-request-id", Fields.REQUEST_ID, true), //
                                                CORRELATION_ID("X-CorrelationID", Fields.CORRELATION_ID, true,
                                                               X_VCAP_REQUEST_ID), //
@@ -26,7 +40,11 @@ public enum HttpHeaders implements HttpHeader {
                                                TENANT_ID("tenantid", Fields.TENANT_ID, true); //
 
     private HttpHeaders(String name) {
-        this(name, null, false);
+        this(name, null);
+    }
+
+    private HttpHeaders(String name, String field) {
+        this(name, field, false);
     }
 
     private HttpHeaders(String name, String field, boolean isPropagated, HttpHeaders... aliases) {

--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/request/HttpHeaders.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/request/HttpHeaders.java
@@ -15,7 +15,10 @@ public enum HttpHeaders implements HttpHeader {
                                                CONTENT_LENGTH("content-length"), //
                                                CONTENT_TYPE("content-type"), //
                                                REFERER("referer"), //
-                                               X_FORWARDED_FOR("x-forwarded-for"), //
+                                               X_CUSTOM_HOST("x-custom-host", Fields.X_CUSTOM_HOST, false), //
+                                               X_FORWARDED_FOR("x-forwarded-for", Fields.X_FORWARDED_FOR, false), //
+                                               X_FORWARDED_HOST("x-forwarded-host", Fields.X_FORWARDED_HOST, false), //
+                                               X_FORWARDED_PROTO("x-forwarded-proto", Fields.X_FORWARDED_PROTO, false), //
                                                X_VCAP_REQUEST_ID("x-vcap-request-id", Fields.REQUEST_ID, true), //
                                                CORRELATION_ID("X-CorrelationID", Fields.CORRELATION_ID, true,
                                                               X_VCAP_REQUEST_ID), //

--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/request/RequestRecordBuilder.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/request/RequestRecordBuilder.java
@@ -6,56 +6,56 @@ import com.sap.hcp.cf.logging.common.request.RequestRecord.Direction;
 
 public class RequestRecordBuilder {
 
-	private final RequestRecord requestRecord;
+    private final RequestRecord requestRecord;
 
-	private RequestRecordBuilder(String layerKey) {
-		this.requestRecord = new RequestRecord(layerKey);
-	}
+    private RequestRecordBuilder(String layerKey) {
+        this.requestRecord = new RequestRecord(layerKey);
+    }
 
-	private RequestRecordBuilder(String layerKey, Direction direction) {
-		this.requestRecord = new RequestRecord(layerKey, direction);
-	}
+    private RequestRecordBuilder(String layerKey, Direction direction) {
+        this.requestRecord = new RequestRecord(layerKey, direction);
+    }
 
-	public static RequestRecordBuilder requestRecord(String layerKey) {
-		return new RequestRecordBuilder(layerKey);
-	}
+    public static RequestRecordBuilder requestRecord(String layerKey) {
+        return new RequestRecordBuilder(layerKey);
+    }
 
-	public static RequestRecordBuilder requestRecord(String layerKey, Direction direction) {
-		return new RequestRecordBuilder(layerKey, direction);
-	}
+    public static RequestRecordBuilder requestRecord(String layerKey, Direction direction) {
+        return new RequestRecordBuilder(layerKey, direction);
+    }
 
-	public RequestRecord build() {
-		return requestRecord;
-	}
+    public RequestRecord build() {
+        return requestRecord;
+    }
 
-	public RequestRecordBuilder addTag(String fieldKey, String tag) {
-		requestRecord.addTag(fieldKey, tag);
-		return this;
-	}
+    public RequestRecordBuilder addTag(String fieldKey, String tag) {
+        requestRecord.addTag(fieldKey, tag);
+        return this;
+    }
 
-	public RequestRecordBuilder addOptionalTag(boolean optionalFieldCanBeLogged, String fieldKey, String tag) {
+    public RequestRecordBuilder addOptionalTag(boolean optionalFieldCanBeLogged, String fieldKey, String tag) {
 
-		if (!optionalFieldCanBeLogged && tag != null) {
-			requestRecord.addTag(fieldKey, Defaults.REDACTED);
-		}
+        if (!optionalFieldCanBeLogged && tag != null) {
+            requestRecord.addTag(fieldKey, Defaults.REDACTED);
+        }
 
         if (!optionalFieldCanBeLogged && Defaults.UNKNOWN.equals(tag)) {
-			requestRecord.addTag(fieldKey, tag);
-		}
+            requestRecord.addTag(fieldKey, tag);
+        }
 
-		if (optionalFieldCanBeLogged) {
-			requestRecord.addTag(fieldKey, tag);
-		}
-		return this;
-	}
+        if (optionalFieldCanBeLogged) {
+            requestRecord.addTag(fieldKey, tag);
+        }
+        return this;
+    }
 
-	public RequestRecordBuilder addContextTag(String fieldKey, String tag) {
-		requestRecord.addContextTag(fieldKey, tag);
-		return this;
-	}
+    public RequestRecordBuilder addContextTag(String fieldKey, String tag) {
+        requestRecord.addContextTag(fieldKey, tag);
+        return this;
+    }
 
-	public RequestRecordBuilder addValue(String fieldKey, Value value) {
-		requestRecord.addValue(fieldKey, value);
-		return this;
-	}
+    public RequestRecordBuilder addValue(String fieldKey, Value value) {
+        requestRecord.addValue(fieldKey, value);
+        return this;
+    }
 }

--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/request/RequestRecordBuilder.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/request/RequestRecordBuilder.java
@@ -39,7 +39,7 @@ public class RequestRecordBuilder {
 			requestRecord.addTag(fieldKey, Defaults.REDACTED);
 		}
 
-		if (!optionalFieldCanBeLogged && tag.equals(Defaults.UNKNOWN)) {
+        if (!optionalFieldCanBeLogged && Defaults.UNKNOWN.equals(tag)) {
 			requestRecord.addTag(fieldKey, tag);
 		}
 

--- a/cf-java-logging-support-core/src/test/java/com/sap/hcp/cf/logging/common/LogOptionalFieldsSettingsTest.java
+++ b/cf-java-logging-support-core/src/test/java/com/sap/hcp/cf/logging/common/LogOptionalFieldsSettingsTest.java
@@ -17,12 +17,14 @@ public class LogOptionalFieldsSettingsTest {
         when(mockEnvironment.getVariable(Environment.LOG_SENSITIVE_CONNECTION_DATA)).thenReturn("true");
         when(mockEnvironment.getVariable(Environment.LOG_REMOTE_USER)).thenReturn("True");
         when(mockEnvironment.getVariable(Environment.LOG_REFERER)).thenReturn("TRUE");
+        when(mockEnvironment.getVariable(Environment.LOG_SSL_HEADERS)).thenReturn("true");
 
         LogOptionalFieldsSettings settings = new LogOptionalFieldsSettings(mockEnvironment, "NameOfInvokingClass");
 
         assertTrue("Wrapping LOG_SENSITIVE_CONNECTION_DATA failed", settings.isLogSensitiveConnectionData());
         assertTrue("Wrapping LOG_REMOTE_USER failed", settings.isLogRemoteUserField());
         assertTrue("Wrapping LOG_REFERER failed", settings.isLogRefererField());
+        assertTrue("Wrapping LOG_SSL_HEADERS failed", settings.isLogSslHeaders());
     }
 
     @Test
@@ -31,12 +33,14 @@ public class LogOptionalFieldsSettingsTest {
         when(mockEnvironment.getVariable(Environment.LOG_SENSITIVE_CONNECTION_DATA)).thenReturn("false");
         when(mockEnvironment.getVariable(Environment.LOG_REMOTE_USER)).thenReturn("False");
         when(mockEnvironment.getVariable(Environment.LOG_REFERER)).thenReturn("FALSE");
+        when(mockEnvironment.getVariable(Environment.LOG_SSL_HEADERS)).thenReturn("false");
 
         LogOptionalFieldsSettings settings = new LogOptionalFieldsSettings(mockEnvironment, "NameOfInvokingClass");
 
         assertFalse("Wrapping LOG_SENSITIVE_CONNECTION_DATA failed", settings.isLogSensitiveConnectionData());
         assertFalse("Wrapping LOG_REMOTE_USER failed", settings.isLogRemoteUserField());
         assertFalse("Wrapping LOG_REFERER failed", settings.isLogRefererField());
+        assertFalse("Wrapping LOG_SSL_HEADERS failed", settings.isLogSslHeaders());
     }
 
     @Test
@@ -45,11 +49,13 @@ public class LogOptionalFieldsSettingsTest {
         when(mockEnvironment.getVariable(Environment.LOG_SENSITIVE_CONNECTION_DATA)).thenReturn("someInvalidString");
         when(mockEnvironment.getVariable(Environment.LOG_REMOTE_USER)).thenReturn("someInvalidString");
         when(mockEnvironment.getVariable(Environment.LOG_REFERER)).thenReturn("someInvalidString");
+        when(mockEnvironment.getVariable(Environment.LOG_SSL_HEADERS)).thenReturn("someInvalidString");
 
         LogOptionalFieldsSettings settings = new LogOptionalFieldsSettings(mockEnvironment, "NameOfInvokingClass");
         assertFalse("Wrapping LOG_SENSITIVE_CONNECTION_DATA failed", settings.isLogSensitiveConnectionData());
         assertFalse("Wrapping LOG_REMOTE_USER failed", settings.isLogRemoteUserField());
         assertFalse("Wrapping LOG_REFERER failed", settings.isLogRefererField());
+        assertFalse("Wrapping LOG_SSL_HEADERS failed", settings.isLogSslHeaders());
     }
 
     @Test
@@ -58,11 +64,13 @@ public class LogOptionalFieldsSettingsTest {
         when(mockEnvironment.getVariable(Environment.LOG_SENSITIVE_CONNECTION_DATA)).thenReturn("");
         when(mockEnvironment.getVariable(Environment.LOG_REMOTE_USER)).thenReturn("");
         when(mockEnvironment.getVariable(Environment.LOG_REFERER)).thenReturn("");
+        when(mockEnvironment.getVariable(Environment.LOG_SSL_HEADERS)).thenReturn("");
 
         LogOptionalFieldsSettings settings = new LogOptionalFieldsSettings(mockEnvironment, "NameOfInvokingClass");
         assertFalse("Wrapping LOG_SENSITIVE_CONNECTION_DATA failed", settings.isLogSensitiveConnectionData());
         assertFalse("Wrapping LOG_REMOTE_USER failed", settings.isLogRemoteUserField());
         assertFalse("Wrapping LOG_REFERER failed", settings.isLogRefererField());
+        assertFalse("Wrapping LOG_SSL_HEADERS failed", settings.isLogSslHeaders());
     }
 
     @Test
@@ -71,12 +79,14 @@ public class LogOptionalFieldsSettingsTest {
         when(mockEnvironment.getVariable(Environment.LOG_SENSITIVE_CONNECTION_DATA)).thenReturn(null);
         when(mockEnvironment.getVariable(Environment.LOG_REMOTE_USER)).thenReturn(null);
         when(mockEnvironment.getVariable(Environment.LOG_REFERER)).thenReturn(null);
+        when(mockEnvironment.getVariable(Environment.LOG_SSL_HEADERS)).thenReturn(null);
 
         LogOptionalFieldsSettings settings = new LogOptionalFieldsSettings(mockEnvironment, "NameOfInvokingClass");
 
         assertFalse("Wrapping LOG_SENSITIVE_CONNECTION_DATA failed", settings.isLogSensitiveConnectionData());
         assertFalse("Wrapping LOG_REMOTE_USER failed", settings.isLogRemoteUserField());
         assertFalse("Wrapping LOG_REFERER failed", settings.isLogRefererField());
+        assertFalse("Wrapping LOG_SSL_HEADERS failed", settings.isLogSslHeaders());
     }
 
     @Test
@@ -85,12 +95,14 @@ public class LogOptionalFieldsSettingsTest {
         when(mockEnvironment.getVariable(Environment.LOG_SENSITIVE_CONNECTION_DATA)).thenReturn("false");
         when(mockEnvironment.getVariable(Environment.LOG_REMOTE_USER)).thenReturn("true");
         when(mockEnvironment.getVariable(Environment.LOG_REFERER)).thenReturn("True");
+        when(mockEnvironment.getVariable(Environment.LOG_SSL_HEADERS)).thenReturn("False");
 
         LogOptionalFieldsSettings settings = new LogOptionalFieldsSettings(mockEnvironment, "NameOfInvokingClass");
 
         assertFalse("Wrapping LOG_SENSITIVE_CONNECTION_DATA failed", settings.isLogSensitiveConnectionData());
         assertTrue("Wrapping LOG_REMOTE_USER failed", settings.isLogRemoteUserField());
         assertTrue("Wrapping LOG_REFERER failed", settings.isLogRefererField());
+        assertFalse("Wrapping LOG_SSL_HEADERS failed", settings.isLogSslHeaders());
     }
 
 }

--- a/cf-java-logging-support-core/src/test/java/com/sap/hcp/cf/logging/common/request/HttpHeadersTest.java
+++ b/cf-java-logging-support-core/src/test/java/com/sap/hcp/cf/logging/common/request/HttpHeadersTest.java
@@ -24,7 +24,7 @@ public class HttpHeadersTest {
 
     @Test
     public void hasCorrectNumberOfTypes() throws Exception {
-        assertThat(HttpHeaders.values().length, is(equalTo(8)));
+        assertThat(HttpHeaders.values().length, is(equalTo(11)));
     }
 
     @Test
@@ -34,7 +34,10 @@ public class HttpHeadersTest {
         assertThat(HttpHeaders.CORRELATION_ID.getName(), is("X-CorrelationID"));
         assertThat(HttpHeaders.REFERER.getName(), is("referer"));
         assertThat(HttpHeaders.TENANT_ID.getName(), is("tenantid"));
+        assertThat(HttpHeaders.X_CUSTOM_HOST.getName(), is("x-custom-host"));
         assertThat(HttpHeaders.X_FORWARDED_FOR.getName(), is("x-forwarded-for"));
+        assertThat(HttpHeaders.X_FORWARDED_HOST.getName(), is("x-forwarded-host"));
+        assertThat(HttpHeaders.X_FORWARDED_PROTO.getName(), is("x-forwarded-proto"));
         assertThat(HttpHeaders.X_VCAP_REQUEST_ID.getName(), is("x-vcap-request-id"));
     }
 
@@ -45,7 +48,10 @@ public class HttpHeadersTest {
         assertThat(HttpHeaders.CORRELATION_ID.getField(), is(Fields.CORRELATION_ID));
         assertThat(HttpHeaders.REFERER.getField(), is(nullValue()));
         assertThat(HttpHeaders.TENANT_ID.getField(), is(Fields.TENANT_ID));
-        assertThat(HttpHeaders.X_FORWARDED_FOR.getField(), is(nullValue()));
+        assertThat(HttpHeaders.X_CUSTOM_HOST.getField(), is(Fields.X_CUSTOM_HOST));
+        assertThat(HttpHeaders.X_FORWARDED_FOR.getField(), is(Fields.X_FORWARDED_FOR));
+        assertThat(HttpHeaders.X_FORWARDED_HOST.getField(), is(Fields.X_FORWARDED_HOST));
+        assertThat(HttpHeaders.X_FORWARDED_PROTO.getField(), is(Fields.X_FORWARDED_PROTO));
         assertThat(HttpHeaders.X_VCAP_REQUEST_ID.getField(), is(Fields.REQUEST_ID));
     }
 
@@ -54,7 +60,6 @@ public class HttpHeadersTest {
         assertThat(HttpHeaders.CONTENT_LENGTH.getFieldValue(), is(Defaults.UNKNOWN));
         assertThat(HttpHeaders.CONTENT_TYPE.getFieldValue(), is(Defaults.UNKNOWN));
         assertThat(HttpHeaders.REFERER.getFieldValue(), is(Defaults.UNKNOWN));
-        assertThat(HttpHeaders.X_FORWARDED_FOR.getFieldValue(), is(Defaults.UNKNOWN));
     }
 
     @Test
@@ -72,7 +77,10 @@ public class HttpHeadersTest {
         assertThat(HttpHeaders.CORRELATION_ID.getAliases(), containsInAnyOrder(HttpHeaders.X_VCAP_REQUEST_ID));
         assertThat(HttpHeaders.REFERER.getAliases(), is(empty()));
         assertThat(HttpHeaders.TENANT_ID.getAliases(), is(empty()));
+        assertThat(HttpHeaders.X_CUSTOM_HOST.getAliases(), is(empty()));
         assertThat(HttpHeaders.X_FORWARDED_FOR.getAliases(), is(empty()));
+        assertThat(HttpHeaders.X_FORWARDED_HOST.getAliases(), is(empty()));
+        assertThat(HttpHeaders.X_FORWARDED_PROTO.getAliases(), is(empty()));
         assertThat(HttpHeaders.X_VCAP_REQUEST_ID.getAliases(), is(empty()));
     }
 

--- a/cf-java-logging-support-core/src/test/java/com/sap/hcp/cf/logging/common/request/HttpHeadersTest.java
+++ b/cf-java-logging-support-core/src/test/java/com/sap/hcp/cf/logging/common/request/HttpHeadersTest.java
@@ -24,7 +24,7 @@ public class HttpHeadersTest {
 
     @Test
     public void hasCorrectNumberOfTypes() throws Exception {
-        assertThat(HttpHeaders.values().length, is(equalTo(11)));
+        assertThat(HttpHeaders.values().length, is(equalTo(19)));
     }
 
     @Test
@@ -39,6 +39,14 @@ public class HttpHeadersTest {
         assertThat(HttpHeaders.X_FORWARDED_HOST.getName(), is("x-forwarded-host"));
         assertThat(HttpHeaders.X_FORWARDED_PROTO.getName(), is("x-forwarded-proto"));
         assertThat(HttpHeaders.X_VCAP_REQUEST_ID.getName(), is("x-vcap-request-id"));
+        assertThat(HttpHeaders.X_SSL_CLIENT.getName(), is("x-ssl-client"));
+        assertThat(HttpHeaders.X_SSL_CLIENT_VERIFY.getName(), is("x-ssl-client-verify"));
+        assertThat(HttpHeaders.X_SSL_CLIENT_SUBJECT_DN.getName(), is("x-ssl-client-subject-dn"));
+        assertThat(HttpHeaders.X_SSL_CLIENT_SUBJECT_CN.getName(), is("x-ssl-client-subject-cn"));
+        assertThat(HttpHeaders.X_SSL_CLIENT_ISSUER_DN.getName(), is("x-ssl-client-issuer-dn"));
+        assertThat(HttpHeaders.X_SSL_CLIENT_NOTBEFORE.getName(), is("x-ssl-client-notbefore"));
+        assertThat(HttpHeaders.X_SSL_CLIENT_NOTAFTER.getName(), is("x-ssl-client-notafter"));
+        assertThat(HttpHeaders.X_SSL_CLIENT_SESSION_ID.getName(), is("x-ssl-client-session-id"));
     }
 
     @Test
@@ -53,6 +61,14 @@ public class HttpHeadersTest {
         assertThat(HttpHeaders.X_FORWARDED_HOST.getField(), is(Fields.X_FORWARDED_HOST));
         assertThat(HttpHeaders.X_FORWARDED_PROTO.getField(), is(Fields.X_FORWARDED_PROTO));
         assertThat(HttpHeaders.X_VCAP_REQUEST_ID.getField(), is(Fields.REQUEST_ID));
+        assertThat(HttpHeaders.X_SSL_CLIENT.getField(), is(Fields.X_SSL_CLIENT));
+        assertThat(HttpHeaders.X_SSL_CLIENT_VERIFY.getField(), is(Fields.X_SSL_CLIENT_VERIFY));
+        assertThat(HttpHeaders.X_SSL_CLIENT_SUBJECT_DN.getField(), is(Fields.X_SSL_CLIENT_SUBJECT_DN));
+        assertThat(HttpHeaders.X_SSL_CLIENT_SUBJECT_CN.getField(), is(Fields.X_SSL_CLIENT_SUBJECT_CN));
+        assertThat(HttpHeaders.X_SSL_CLIENT_ISSUER_DN.getField(), is(Fields.X_SSL_CLIENT_ISSUER_DN));
+        assertThat(HttpHeaders.X_SSL_CLIENT_NOTBEFORE.getField(), is(Fields.X_SSL_CLIENT_NOTBEFORE));
+        assertThat(HttpHeaders.X_SSL_CLIENT_NOTAFTER.getField(), is(Fields.X_SSL_CLIENT_NOTAFTER));
+        assertThat(HttpHeaders.X_SSL_CLIENT_SESSION_ID.getField(), is(Fields.X_SSL_CLIENT_SESSION_ID));
     }
 
     @Test
@@ -82,6 +98,14 @@ public class HttpHeadersTest {
         assertThat(HttpHeaders.X_FORWARDED_HOST.getAliases(), is(empty()));
         assertThat(HttpHeaders.X_FORWARDED_PROTO.getAliases(), is(empty()));
         assertThat(HttpHeaders.X_VCAP_REQUEST_ID.getAliases(), is(empty()));
+        assertThat(HttpHeaders.X_SSL_CLIENT.getAliases(), is(empty()));
+        assertThat(HttpHeaders.X_SSL_CLIENT_VERIFY.getAliases(), is(empty()));
+        assertThat(HttpHeaders.X_SSL_CLIENT_SUBJECT_DN.getAliases(), is(empty()));
+        assertThat(HttpHeaders.X_SSL_CLIENT_SUBJECT_CN.getAliases(), is(empty()));
+        assertThat(HttpHeaders.X_SSL_CLIENT_ISSUER_DN.getAliases(), is(empty()));
+        assertThat(HttpHeaders.X_SSL_CLIENT_NOTBEFORE.getAliases(), is(empty()));
+        assertThat(HttpHeaders.X_SSL_CLIENT_NOTAFTER.getAliases(), is(empty()));
+        assertThat(HttpHeaders.X_SSL_CLIENT_SESSION_ID.getAliases(), is(empty()));
     }
 
     @Test

--- a/cf-java-logging-support-servlet/src/main/java/com/sap/hcp/cf/logging/servlet/filter/RequestRecordFactory.java
+++ b/cf-java-logging-support-servlet/src/main/java/com/sap/hcp/cf/logging/servlet/filter/RequestRecordFactory.java
@@ -15,42 +15,47 @@ import com.sap.hcp.cf.logging.common.request.RequestRecordBuilder;
 
 public class RequestRecordFactory {
 
-	private final LogOptionalFieldsSettings logOptionalFieldsSettings;
+    private final LogOptionalFieldsSettings logOptionalFieldsSettings;
 
-	public RequestRecordFactory(LogOptionalFieldsSettings logOptionalFieldsSettings) {
-		this.logOptionalFieldsSettings = logOptionalFieldsSettings;
-	}
+    public RequestRecordFactory(LogOptionalFieldsSettings logOptionalFieldsSettings) {
+        this.logOptionalFieldsSettings = logOptionalFieldsSettings;
+    }
 
-	public RequestRecord create(HttpServletRequest request) {
-		boolean isSensitiveConnectionData = logOptionalFieldsSettings.isLogSensitiveConnectionData();
-		boolean isLogRemoteUserField = logOptionalFieldsSettings.isLogRemoteUserField();
-		boolean isLogRefererField = logOptionalFieldsSettings.isLogRefererField();
-		RequestRecordBuilder rrb =  requestRecord("[SERVLET]").addTag(Fields.REQUEST, getFullRequestUri(request))
-				.addTag(Fields.METHOD, request.getMethod())
-				.addTag(Fields.PROTOCOL, getValue(request.getProtocol()))
-				.addOptionalTag(isSensitiveConnectionData, Fields.REMOTE_IP, getValue(request.getRemoteAddr()))
-				.addOptionalTag(isSensitiveConnectionData, Fields.REMOTE_HOST, getValue(request.getRemoteHost()))
-				.addOptionalTag(isSensitiveConnectionData, Fields.REMOTE_PORT,
-						Integer.toString(request.getRemotePort()))
-				.addOptionalTag(isSensitiveConnectionData, Fields.X_FORWARDED_FOR,
-						getHeader(request, HttpHeaders.X_FORWARDED_FOR))
-				.addOptionalTag(isLogRemoteUserField, Fields.REMOTE_USER, getValue(request.getRemoteUser()))
-				.addOptionalTag(isLogRefererField, Fields.REFERER, getHeader(request, HttpHeaders.REFERER));
-		return rrb.build();
-	}
+    public RequestRecord create(HttpServletRequest request) {
+        boolean isSensitiveConnectionData = logOptionalFieldsSettings.isLogSensitiveConnectionData();
+        boolean isLogRemoteUserField = logOptionalFieldsSettings.isLogRemoteUserField();
+        boolean isLogRefererField = logOptionalFieldsSettings.isLogRefererField();
+        RequestRecordBuilder rrb = requestRecord("[SERVLET]");
+        rrb.addTag(Fields.REQUEST, getFullRequestUri(request)).addTag(Fields.METHOD, request.getMethod()) //
+           .addTag(Fields.PROTOCOL, getValue(request.getProtocol())) //
+           .addOptionalTag(isSensitiveConnectionData, Fields.REMOTE_IP, getValue(request.getRemoteAddr())) //
+           .addOptionalTag(isSensitiveConnectionData, Fields.REMOTE_HOST, getValue(request.getRemoteHost())) //
+           .addOptionalTag(isSensitiveConnectionData, Fields.REMOTE_PORT, Integer.toString(request.getRemotePort())) //
+           .addOptionalTag(isSensitiveConnectionData, HttpHeaders.X_CUSTOM_HOST.getField(), getHeaderValue(request,
+                                                                                                           HttpHeaders.X_CUSTOM_HOST)) //
+           .addOptionalTag(isSensitiveConnectionData, HttpHeaders.X_FORWARDED_FOR.getField(), getHeaderValue(request,
+                                                                                                             HttpHeaders.X_FORWARDED_FOR)) //
+           .addOptionalTag(isSensitiveConnectionData, HttpHeaders.X_FORWARDED_HOST.getField(), getHeaderValue(request,
+                                                                                                              HttpHeaders.X_FORWARDED_HOST)) //
+           .addOptionalTag(isSensitiveConnectionData, HttpHeaders.X_FORWARDED_PROTO.getField(), getHeaderValue(request,
+                                                                                                               HttpHeaders.X_FORWARDED_PROTO)) //
+           .addOptionalTag(isLogRemoteUserField, Fields.REMOTE_USER, getValue(request.getRemoteUser())) //
+           .addOptionalTag(isLogRefererField, Fields.REFERER, getHeader(request, HttpHeaders.REFERER));
+        return rrb.build();
+    }
 
-	private String getFullRequestUri(HttpServletRequest request) {
-		String queryString = request.getQueryString();
-		String requestURI = request.getRequestURI();
-		return queryString != null ? requestURI + "?" + queryString : requestURI;
-	}
+    private String getFullRequestUri(HttpServletRequest request) {
+        String queryString = request.getQueryString();
+        String requestURI = request.getRequestURI();
+        return queryString != null ? requestURI + "?" + queryString : requestURI;
+    }
 
-	private String getHeader(HttpServletRequest request, HttpHeader header) {
-		return getHeaderValue(request, header, Defaults.UNKNOWN);
-	}
+    private String getHeader(HttpServletRequest request, HttpHeader header) {
+        return getHeaderValue(request, header, Defaults.UNKNOWN);
+    }
 
-	private String getValue(String value) {
-		return value != null ? value : Defaults.UNKNOWN;
-	}
+    private String getValue(String value) {
+        return value != null ? value : Defaults.UNKNOWN;
+    }
 
 }

--- a/cf-java-logging-support-servlet/src/test/java/com/sap/hcp/cf/logging/servlet/filter/RequestLoggingFilterTest.java
+++ b/cf-java-logging-support-servlet/src/test/java/com/sap/hcp/cf/logging/servlet/filter/RequestLoggingFilterTest.java
@@ -44,189 +44,222 @@ import com.sap.hcp.cf.logging.common.request.HttpHeaders;
 
 public class RequestLoggingFilterTest {
 
-	private static final String REQUEST_ID = "1234-56-7890-xxx";
-	private static final String CORRELATION_ID = "xxx-56-7890-xxx";
-	private static final String TENANT_ID = "tenant1";
-	private static final String REQUEST = "/foobar";
-	private static final String QUERY_STRING = "baz=bla";
-	private static final String FULL_REQUEST = REQUEST + "?" + QUERY_STRING;
-	private static final String REMOTE_HOST = "acme.org";
-	private static final String REFERER = "my.fancy.com";
+    private static final String REQUEST_ID = "1234-56-7890-xxx";
+    private static final String CORRELATION_ID = "xxx-56-7890-xxx";
+    private static final String TENANT_ID = "tenant1";
+    private static final String REQUEST = "/foobar";
+    private static final String QUERY_STRING = "baz=bla";
+    private static final String FULL_REQUEST = REQUEST + "?" + QUERY_STRING;
+    private static final String REMOTE_HOST = "acme.org";
+    private static final String REFERER = "my.fancy.com";
 
-	@Rule
-	public SystemOutRule systemOut = new SystemOutRule();
+    @Rule
+    public SystemOutRule systemOut = new SystemOutRule();
 
-	@Rule
-	public SystemErrRule systemErr = new SystemErrRule();
+    @Rule
+    public SystemErrRule systemErr = new SystemErrRule();
 
-	private HttpServletRequest mockReq = mock(HttpServletRequest.class);
-	private HttpServletResponse mockResp = mock(HttpServletResponse.class);
-	private PrintWriter mockWriter = mock(PrintWriter.class);
+    private HttpServletRequest mockReq = mock(HttpServletRequest.class);
+    private HttpServletResponse mockResp = mock(HttpServletResponse.class);
+    private PrintWriter mockWriter = mock(PrintWriter.class);
 
-	@Before
-	public void initMocks() throws IOException {
-		Mockito.reset(mockReq, mockResp, mockWriter);
-		when(mockResp.getWriter()).thenReturn(mockWriter);
+    @Before
+    public void initMocks() throws IOException {
+        Mockito.reset(mockReq, mockResp, mockWriter);
+        when(mockResp.getWriter()).thenReturn(mockWriter);
 
-		Map<String, String> contextMap = new HashMap<>();
-		Mockito.doAnswer(new Answer<Void>() {
-			@SuppressWarnings("unchecked")
-			@Override
-			public Void answer(InvocationOnMock invocation) throws Throwable {
-				Object[] arguments = invocation.getArguments();
-				contextMap.clear();
-				contextMap.putAll((Map<? extends String, ? extends String>) arguments[1]);
-				return null;
-			}
-		}).when(mockReq).setAttribute(eq(MDC.class.getName()), anyMapOf(String.class, String.class));
+        Map<String, String> contextMap = new HashMap<>();
+        Mockito.doAnswer(new Answer<Void>() {
+            @SuppressWarnings("unchecked")
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                Object[] arguments = invocation.getArguments();
+                contextMap.clear();
+                contextMap.putAll((Map<? extends String, ? extends String>) arguments[1]);
+                return null;
+            }
+        }).when(mockReq).setAttribute(eq(MDC.class.getName()), anyMapOf(String.class, String.class));
 
-		when(mockReq.getAttribute(MDC.class.getName())).thenReturn(contextMap);
-	}
+        when(mockReq.getAttribute(MDC.class.getName())).thenReturn(contextMap);
+    }
 
-	@Test
-	public void testSimple() throws IOException, ServletException {
-		FilterChain mockFilterChain = mock(FilterChain.class);
-		
+    @Test
+    public void testSimple() throws IOException, ServletException {
+        FilterChain mockFilterChain = mock(FilterChain.class);
+
         new RequestLoggingFilter().doFilter(mockReq, mockResp, mockFilterChain);
-		assertThat(getField(Fields.REQUEST), is(Defaults.UNKNOWN));
-		assertThat(getField(Fields.CORRELATION_ID), not(isEmptyOrNullString()));
-		assertThat(getField(Fields.REQUEST_ID), is(nullValue()));
-		assertThat(getField(Fields.REMOTE_HOST), is(Defaults.UNKNOWN));
-		assertThat(getField(Fields.COMPONENT_ID), is(Defaults.UNKNOWN));
-		assertThat(getField(Fields.CONTAINER_ID), is(Defaults.UNKNOWN));
-		assertThat(getField(Fields.REQUEST_SIZE_B), is("-1"));
-	}
+        assertThat(getField(Fields.REQUEST), is(Defaults.UNKNOWN));
+        assertThat(getField(Fields.CORRELATION_ID), not(isEmptyOrNullString()));
+        assertThat(getField(Fields.REQUEST_ID), is(nullValue()));
+        assertThat(getField(Fields.REMOTE_HOST), is(Defaults.UNKNOWN));
+        assertThat(getField(Fields.COMPONENT_ID), is(Defaults.UNKNOWN));
+        assertThat(getField(Fields.CONTAINER_ID), is(Defaults.UNKNOWN));
+        assertThat(getField(Fields.REQUEST_SIZE_B), is("-1"));
+    }
 
-	@Test
-	public void testInputStream() throws IOException, ServletException {
-		ServletInputStream mockStream = mock(ServletInputStream.class);
+    @Test
+    public void testInputStream() throws IOException, ServletException {
+        ServletInputStream mockStream = mock(ServletInputStream.class);
 
-		when(mockReq.getInputStream()).thenReturn(mockStream);
-		when(mockStream.read()).thenReturn(1);
-		FilterChain mockFilterChain = new FilterChain() {
-			@Override
-			public void doFilter(ServletRequest request, ServletResponse response)
-					throws IOException, ServletException {
-				request.getInputStream().read();
-			}
-		};
+        when(mockReq.getInputStream()).thenReturn(mockStream);
+        when(mockStream.read()).thenReturn(1);
+        FilterChain mockFilterChain = new FilterChain() {
+            @Override
+            public void doFilter(ServletRequest request, ServletResponse response) throws IOException,
+                                                                                   ServletException {
+                request.getInputStream().read();
+            }
+        };
         new RequestLoggingFilter().doFilter(mockReq, mockResp, mockFilterChain);
-		assertThat(getField(Fields.REQUEST), is(Defaults.UNKNOWN));
-		assertThat(getField(Fields.CORRELATION_ID), not(isEmptyOrNullString()));
-		assertThat(getField(Fields.REQUEST_ID), is(nullValue()));
-		assertThat(getField(Fields.REMOTE_HOST), is(Defaults.UNKNOWN));
-		assertThat(getField(Fields.COMPONENT_ID), is(Defaults.UNKNOWN));
-		assertThat(getField(Fields.CONTAINER_ID), is(Defaults.UNKNOWN));
-		assertThat(getField(Fields.REQUEST_SIZE_B), is("1"));
-	}
+        assertThat(getField(Fields.REQUEST), is(Defaults.UNKNOWN));
+        assertThat(getField(Fields.CORRELATION_ID), not(isEmptyOrNullString()));
+        assertThat(getField(Fields.REQUEST_ID), is(nullValue()));
+        assertThat(getField(Fields.REMOTE_HOST), is(Defaults.UNKNOWN));
+        assertThat(getField(Fields.COMPONENT_ID), is(Defaults.UNKNOWN));
+        assertThat(getField(Fields.CONTAINER_ID), is(Defaults.UNKNOWN));
+        assertThat(getField(Fields.REQUEST_SIZE_B), is("1"));
+    }
 
-	@Test
-	public void testReader() throws IOException, ServletException {
-		BufferedReader reader = new BufferedReader(new StringReader("TEST"));
+    @Test
+    public void testReader() throws IOException, ServletException {
+        BufferedReader reader = new BufferedReader(new StringReader("TEST"));
 
-		when(mockReq.getReader()).thenReturn(reader);
-		FilterChain mockFilterChain = new FilterChain() {
-			@Override
-			public void doFilter(ServletRequest request, ServletResponse response)
-					throws IOException, ServletException {
-				request.getReader().read();
-			}
-		};
+        when(mockReq.getReader()).thenReturn(reader);
+        FilterChain mockFilterChain = new FilterChain() {
+            @Override
+            public void doFilter(ServletRequest request, ServletResponse response) throws IOException,
+                                                                                   ServletException {
+                request.getReader().read();
+            }
+        };
         new RequestLoggingFilter().doFilter(mockReq, mockResp, mockFilterChain);
-		assertThat(getField(Fields.REQUEST), is(Defaults.UNKNOWN));
-		assertThat(getField(Fields.CORRELATION_ID), not(isEmptyOrNullString()));
-		assertThat(getField(Fields.REQUEST_ID), is(nullValue()));
-		assertThat(getField(Fields.REMOTE_HOST), is(Defaults.UNKNOWN));
-		assertThat(getField(Fields.COMPONENT_ID), is(Defaults.UNKNOWN));
-		assertThat(getField(Fields.CONTAINER_ID), is(Defaults.UNKNOWN));
-		assertThat(getField(Fields.REQUEST_SIZE_B), is("4"));
-		assertThat(getField(Fields.TENANT_ID), is(Defaults.UNKNOWN));
-	}
+        assertThat(getField(Fields.REQUEST), is(Defaults.UNKNOWN));
+        assertThat(getField(Fields.CORRELATION_ID), not(isEmptyOrNullString()));
+        assertThat(getField(Fields.REQUEST_ID), is(nullValue()));
+        assertThat(getField(Fields.REMOTE_HOST), is(Defaults.UNKNOWN));
+        assertThat(getField(Fields.COMPONENT_ID), is(Defaults.UNKNOWN));
+        assertThat(getField(Fields.CONTAINER_ID), is(Defaults.UNKNOWN));
+        assertThat(getField(Fields.REQUEST_SIZE_B), is("4"));
+        assertThat(getField(Fields.TENANT_ID), is(Defaults.UNKNOWN));
+    }
 
-	@Test
-	public void testWithActivatedOptionalFields() throws IOException, ServletException {
-		when(mockReq.getRequestURI()).thenReturn(REQUEST);
-		when(mockReq.getQueryString()).thenReturn(QUERY_STRING);
-		when(mockReq.getRemoteHost()).thenReturn(REMOTE_HOST);
-		// will also set correlation id
-		mockGetHeader(HttpHeaders.X_VCAP_REQUEST_ID, REQUEST_ID);
-		mockGetHeader(HttpHeaders.REFERER, REFERER);
-		FilterChain mockFilterChain = mock(FilterChain.class);
-		LogOptionalFieldsSettings mockOptionalFieldsSettings = mock(LogOptionalFieldsSettings.class);
-		when(mockOptionalFieldsSettings.isLogSensitiveConnectionData()).thenReturn(true);
-		when(mockOptionalFieldsSettings.isLogRemoteUserField()).thenReturn(true);
-		when(mockOptionalFieldsSettings.isLogRefererField()).thenReturn(true);
-		RequestRecordFactory requestRecordFactory = new RequestRecordFactory(mockOptionalFieldsSettings);
+    @Test
+    public void testWithActivatedOptionalFields() throws IOException, ServletException {
+        when(mockReq.getRequestURI()).thenReturn(REQUEST);
+        when(mockReq.getQueryString()).thenReturn(QUERY_STRING);
+        when(mockReq.getRemoteHost()).thenReturn(REMOTE_HOST);
+        // will also set correlation id
+        mockGetHeader(HttpHeaders.X_VCAP_REQUEST_ID, REQUEST_ID);
+        mockGetHeader(HttpHeaders.REFERER, REFERER);
+        FilterChain mockFilterChain = mock(FilterChain.class);
+        LogOptionalFieldsSettings mockOptionalFieldsSettings = mock(LogOptionalFieldsSettings.class);
+        when(mockOptionalFieldsSettings.isLogSensitiveConnectionData()).thenReturn(true);
+        when(mockOptionalFieldsSettings.isLogRemoteUserField()).thenReturn(true);
+        when(mockOptionalFieldsSettings.isLogRefererField()).thenReturn(true);
+        RequestRecordFactory requestRecordFactory = new RequestRecordFactory(mockOptionalFieldsSettings);
         Filter requestLoggingFilter = new RequestLoggingFilter(requestRecordFactory);
-		requestLoggingFilter.doFilter(mockReq, mockResp, mockFilterChain);
-		assertThat(getField(Fields.REQUEST), is(FULL_REQUEST));
-		assertThat(getField(Fields.CORRELATION_ID), is(REQUEST_ID));
-		assertThat(getField(Fields.REQUEST_ID), is(REQUEST_ID));
-		assertThat(getField(Fields.REMOTE_HOST), is(REMOTE_HOST));
-		assertThat(getField(Fields.COMPONENT_ID), is(Defaults.UNKNOWN));
-		assertThat(getField(Fields.CONTAINER_ID), is(Defaults.UNKNOWN));
-		assertThat(getField(Fields.REFERER), is(REFERER));
-		assertThat(getField(Fields.TENANT_ID), is(Defaults.UNKNOWN));
-	}
+        requestLoggingFilter.doFilter(mockReq, mockResp, mockFilterChain);
+        assertThat(getField(Fields.REQUEST), is(FULL_REQUEST));
+        assertThat(getField(Fields.CORRELATION_ID), is(REQUEST_ID));
+        assertThat(getField(Fields.REQUEST_ID), is(REQUEST_ID));
+        assertThat(getField(Fields.REMOTE_HOST), is(REMOTE_HOST));
+        assertThat(getField(Fields.COMPONENT_ID), is(Defaults.UNKNOWN));
+        assertThat(getField(Fields.CONTAINER_ID), is(Defaults.UNKNOWN));
+        assertThat(getField(Fields.REFERER), is(REFERER));
+        assertThat(getField(Fields.TENANT_ID), is(Defaults.UNKNOWN));
+    }
 
-	private void mockGetHeader(HttpHeader header, String value) {
-		when(mockReq.getHeader(header.getName())).thenReturn(value);
-	}
+    private void mockGetHeader(HttpHeader header, String value) {
+        when(mockReq.getHeader(header.getName())).thenReturn(value);
+    }
 
-	@Test
-	public void testWithSuppressedOptionalFields() throws IOException, ServletException {
-		when(mockReq.getRequestURI()).thenReturn(REQUEST);
-		when(mockReq.getQueryString()).thenReturn(QUERY_STRING);
-		when(mockReq.getRemoteHost()).thenReturn(REMOTE_HOST);
-		// will also set correlation id
-		mockGetHeader(HttpHeaders.X_VCAP_REQUEST_ID, REQUEST_ID);
-		mockGetHeader(HttpHeaders.REFERER, REFERER);
-		FilterChain mockFilterChain = mock(FilterChain.class);
-		LogOptionalFieldsSettings mockLogOptionalFieldsSettings = mock(LogOptionalFieldsSettings.class);
-		when(mockLogOptionalFieldsSettings.isLogSensitiveConnectionData()).thenReturn(false);
-		when(mockLogOptionalFieldsSettings.isLogRemoteUserField()).thenReturn(false);
-		when(mockLogOptionalFieldsSettings.isLogRefererField()).thenReturn(false);
-		RequestRecordFactory requestRecordFactory = new RequestRecordFactory(mockLogOptionalFieldsSettings);
+    @Test
+    public void testWithSuppressedOptionalFields() throws IOException, ServletException {
+        when(mockReq.getRequestURI()).thenReturn(REQUEST);
+        when(mockReq.getQueryString()).thenReturn(QUERY_STRING);
+        when(mockReq.getRemoteHost()).thenReturn(REMOTE_HOST);
+        // will also set correlation id
+        mockGetHeader(HttpHeaders.X_VCAP_REQUEST_ID, REQUEST_ID);
+        mockGetHeader(HttpHeaders.REFERER, REFERER);
+        FilterChain mockFilterChain = mock(FilterChain.class);
+        LogOptionalFieldsSettings mockLogOptionalFieldsSettings = mock(LogOptionalFieldsSettings.class);
+        when(mockLogOptionalFieldsSettings.isLogSensitiveConnectionData()).thenReturn(false);
+        when(mockLogOptionalFieldsSettings.isLogRemoteUserField()).thenReturn(false);
+        when(mockLogOptionalFieldsSettings.isLogRefererField()).thenReturn(false);
+        RequestRecordFactory requestRecordFactory = new RequestRecordFactory(mockLogOptionalFieldsSettings);
         Filter requestLoggingFilter = new RequestLoggingFilter(requestRecordFactory);
-		requestLoggingFilter.doFilter(mockReq, mockResp, mockFilterChain);
-		assertThat(getField(Fields.REQUEST), is(FULL_REQUEST));
-		assertThat(getField(Fields.CORRELATION_ID), is(REQUEST_ID));
-		assertThat(getField(Fields.REQUEST_ID), is(REQUEST_ID));
-		assertThat(getField(Fields.REMOTE_IP), is(Defaults.UNKNOWN));
-		assertThat(getField(Fields.REMOTE_HOST), is(Defaults.REDACTED));
-		assertThat(getField(Fields.COMPONENT_ID), is(Defaults.UNKNOWN));
-		assertThat(getField(Fields.CONTAINER_ID), is(Defaults.UNKNOWN));
-		assertThat(getField(Fields.TENANT_ID), is(Defaults.UNKNOWN));
-	}
+        requestLoggingFilter.doFilter(mockReq, mockResp, mockFilterChain);
+        assertThat(getField(Fields.REQUEST), is(FULL_REQUEST));
+        assertThat(getField(Fields.CORRELATION_ID), is(REQUEST_ID));
+        assertThat(getField(Fields.REQUEST_ID), is(REQUEST_ID));
+        assertThat(getField(Fields.REMOTE_IP), is(Defaults.UNKNOWN));
+        assertThat(getField(Fields.REMOTE_HOST), is(Defaults.REDACTED));
+        assertThat(getField(Fields.COMPONENT_ID), is(Defaults.UNKNOWN));
+        assertThat(getField(Fields.CONTAINER_ID), is(Defaults.UNKNOWN));
+        assertThat(getField(Fields.TENANT_ID), is(Defaults.UNKNOWN));
+    }
 
-	@Test
-	public void testExplicitCorrelationId() throws IOException, ServletException {
-		mockGetHeader(HttpHeaders.CORRELATION_ID, CORRELATION_ID);
-		mockGetHeader(HttpHeaders.X_VCAP_REQUEST_ID, REQUEST_ID);
-		FilterChain mockFilterChain = mock(FilterChain.class);
+    @Test
+    public void testExplicitCorrelationId() throws IOException, ServletException {
+        mockGetHeader(HttpHeaders.CORRELATION_ID, CORRELATION_ID);
+        mockGetHeader(HttpHeaders.X_VCAP_REQUEST_ID, REQUEST_ID);
+        FilterChain mockFilterChain = mock(FilterChain.class);
         new RequestLoggingFilter().doFilter(mockReq, mockResp, mockFilterChain);
-		assertThat(getField(Fields.CORRELATION_ID), is(CORRELATION_ID));
-		assertThat(getField(Fields.CORRELATION_ID), not(REQUEST_ID));
-		assertThat(getField(Fields.REQUEST_ID), is(REQUEST_ID));
-		assertThat(getField(Fields.TENANT_ID), is(Defaults.UNKNOWN));
-	}
+        assertThat(getField(Fields.CORRELATION_ID), is(CORRELATION_ID));
+        assertThat(getField(Fields.CORRELATION_ID), not(REQUEST_ID));
+        assertThat(getField(Fields.REQUEST_ID), is(REQUEST_ID));
+        assertThat(getField(Fields.TENANT_ID), is(Defaults.UNKNOWN));
+    }
 
-	@Test
-	public void testExplicitTenantId() throws IOException, ServletException {
-		mockGetHeader(HttpHeaders.TENANT_ID, TENANT_ID);
-		mockGetHeader(HttpHeaders.X_VCAP_REQUEST_ID, REQUEST_ID);
-		FilterChain mockFilterChain = mock(FilterChain.class);
+    @Test
+    public void testExplicitTenantId() throws IOException, ServletException {
+        mockGetHeader(HttpHeaders.TENANT_ID, TENANT_ID);
+        mockGetHeader(HttpHeaders.X_VCAP_REQUEST_ID, REQUEST_ID);
+        FilterChain mockFilterChain = mock(FilterChain.class);
         new RequestLoggingFilter().doFilter(mockReq, mockResp, mockFilterChain);
-		assertThat(getField(Fields.TENANT_ID), is(TENANT_ID));
-	}
-	
-	protected String getField(String fieldName) throws JSONObjectException, IOException {
-		Object fieldValue = JSON.std.mapFrom(getLastLine()).get(fieldName);
+        assertThat(getField(Fields.TENANT_ID), is(TENANT_ID));
+    }
+
+    @Test
+    public void testProxyHeadersLogged() throws Exception {
+        LogOptionalFieldsSettings settings = mock(LogOptionalFieldsSettings.class);
+        when(settings.isLogSensitiveConnectionData()).thenReturn(true).getMock();
+        mockGetHeader(HttpHeaders.X_CUSTOM_HOST, "custom.example.com");
+        mockGetHeader(HttpHeaders.X_FORWARDED_FOR, "1.2.3.4,5.6.7.8");
+        mockGetHeader(HttpHeaders.X_FORWARDED_HOST, "requested.example.com");
+        mockGetHeader(HttpHeaders.X_FORWARDED_PROTO, "https");
+        FilterChain mockFilterChain = mock(FilterChain.class);
+        RequestLoggingFilter filter = new RequestLoggingFilter(new RequestRecordFactory(settings));
+        filter.doFilter(mockReq, mockResp, mockFilterChain);
+        assertThat(getField(Fields.X_CUSTOM_HOST), is("custom.example.com"));
+        assertThat(getField(Fields.X_FORWARDED_FOR), is("1.2.3.4,5.6.7.8"));
+        assertThat(getField(Fields.X_FORWARDED_HOST), is("requested.example.com"));
+        assertThat(getField(Fields.X_FORWARDED_PROTO), is("https"));
+    }
+
+    @Test
+    public void testProxyHeadersRedactedByDefault() throws Exception {
+        mockGetHeader(HttpHeaders.X_CUSTOM_HOST, "custom.example.com");
+        mockGetHeader(HttpHeaders.X_FORWARDED_FOR, "1.2.3.4,5.6.7.8");
+        mockGetHeader(HttpHeaders.X_FORWARDED_HOST, "requested.example.com");
+        mockGetHeader(HttpHeaders.X_FORWARDED_PROTO, "https");
+        FilterChain mockFilterChain = mock(FilterChain.class);
+        RequestLoggingFilter filter = new RequestLoggingFilter();
+        filter.doFilter(mockReq, mockResp, mockFilterChain);
+        assertThat(getField(Fields.X_CUSTOM_HOST), is("redacted"));
+        assertThat(getField(Fields.X_FORWARDED_FOR), is("redacted"));
+        assertThat(getField(Fields.X_FORWARDED_HOST), is("redacted"));
+        assertThat(getField(Fields.X_FORWARDED_PROTO), is("redacted"));
+    }
+
+
+    protected String getField(String fieldName) throws JSONObjectException, IOException {
+        Object fieldValue = JSON.std.mapFrom(getLastLine()).get(fieldName);
         return fieldValue == null ? null : fieldValue.toString();
-	}
+    }
 
-	private String getLastLine() {
-		String[] lines = systemOut.toString().split("\n");
-		return lines[lines.length - 1];
-	}
+    private String getLastLine() {
+        String[] lines = systemOut.toString().split("\n");
+        return lines[lines.length - 1];
+    }
 }


### PR DESCRIPTION
This PR addresses several http headers, that may be generated by reverse proxies for incoming http requests. They are added to the request logs generated by the library, provided that certain environment variables are set. See the commit messages for details. The documentation will be changed accordingly.