### PR TITLE
Fix invalid JSON messages

### DIFF
--- a/cf-java-logging-support-log4j2/src/main/java/com/sap/hcp/cf/log4j2/converter/ContextPropsConverter.java
+++ b/cf-java-logging-support-log4j2/src/main/java/com/sap/hcp/cf/log4j2/converter/ContextPropsConverter.java
@@ -51,10 +51,11 @@ public class ContextPropsConverter extends LogEventPatternConverter {
 		addCustomFieldsFromArguments(contextData, event);
         int lengthBefore = toAppendTo.length();
 		converter.convert(toAppendTo, contextData);
-        // append comma only, if at least one field was added
-        // otherwise, there will be to commas ",," rendering the JSON invalid
-        if (toAppendTo.length() > lengthBefore) {
-            toAppendTo.append(",");
+        // remove comma from pattern, when no properties are added
+        // this is to avoid a double comma in the JSON
+        // Do not do this on empty messages
+        if (toAppendTo.length() == lengthBefore && lengthBefore > 0 && toAppendTo.charAt(lengthBefore - 1) == ',') {
+            toAppendTo.setLength(lengthBefore - 1);
         }
 	}
 

--- a/cf-java-logging-support-log4j2/src/main/java/com/sap/hcp/cf/log4j2/layout/LayoutPatternBuilder.java
+++ b/cf-java-logging-support-log4j2/src/main/java/com/sap/hcp/cf/log4j2/layout/LayoutPatternBuilder.java
@@ -56,6 +56,7 @@ public final class LayoutPatternBuilder {
 		sb.append("%").append(ContextPropsConverter.WORD);
         appendParameters(asList(Boolean.toString(sendDefaultValues)));
 		appendParameters(exclusions);
+        sb.append(",");
 		return this;
 	}
 

--- a/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/log4j2/converter/ContextPropsConverterTest.java
+++ b/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/log4j2/converter/ContextPropsConverterTest.java
@@ -9,8 +9,6 @@ import static org.hamcrest.core.Is.is;
 import java.io.IOException;
 import java.util.Map;
 
-import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.pattern.LogEventPatternConverter;
 import org.junit.Test;
 import org.slf4j.MDC;
 
@@ -106,11 +104,5 @@ public class ContextPropsConverterTest extends AbstractConverterTest {
 		assertThat(mapFrom(format(cpc, makeEvent(TEST_MSG_NO_ARGS, customField(SOME_KEY, SOME_VALUE)))),
 				not(hasEntry(SOME_KEY, SOME_VALUE)));
 	}
-
-    @Override
-    protected String format(LogEventPatternConverter cpc, LogEvent event) {
-        String converted = super.format(cpc, event);
-        return converted.length() > 0 ? converted.substring(0, converted.length() - 1) : converted;
-    }
 
 }

--- a/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/log4j2/layout/LayoutPatternBuilderTest.java
+++ b/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/log4j2/layout/LayoutPatternBuilderTest.java
@@ -107,7 +107,7 @@ public class LayoutPatternBuilderTest {
 				.suppressExceptions().build();
 
 		assertThat(pattern, specificPart(is(
-                                            ",\"type\":\"log\",\"logger\":\"%replace{%logger}{\"}{\\\\\"}\",\"thread\":\"%replace{%thread}{\"}{\\\\\"}\",\"level\":\"%p\",\"categories\":%categories,\"msg\":%jsonmsg{escape},%ctxp{false}{excluded-field}\"#cf\":{%cf{custom-field}}%ex{0} ")));
+                                            ",\"type\":\"log\",\"logger\":\"%replace{%logger}{\"}{\\\\\"}\",\"thread\":\"%replace{%thread}{\"}{\\\\\"}\",\"level\":\"%p\",\"categories\":%categories,\"msg\":%jsonmsg{escape},%ctxp{false}{excluded-field},\"#cf\":{%cf{custom-field}}%ex{0} ")));
 	}
 
 	@Test
@@ -117,7 +117,7 @@ public class LayoutPatternBuilderTest {
 				.build();
 
 		assertThat(pattern, specificPart(is(
-                                            ",\"type\":\"log\",\"logger\":\"%replace{%logger}{\"}{\\\\\"}\",\"thread\":\"%replace{%thread}{\"}{\\\\\"}\",\"level\":\"%p\",\"categories\":%categories,\"msg\":%jsonmsg{escape},%ctxp{false}{excluded-field}\"#cf\":{%cf{custom-field}},\"stacktrace\":%stacktrace")));
+                                            ",\"type\":\"log\",\"logger\":\"%replace{%logger}{\"}{\\\\\"}\",\"thread\":\"%replace{%thread}{\"}{\\\\\"}\",\"level\":\"%p\",\"categories\":%categories,\"msg\":%jsonmsg{escape},%ctxp{false}{excluded-field},\"#cf\":{%cf{custom-field}},\"stacktrace\":%stacktrace")));
 	}
 
 	private static Matcher<String> specificPart(Matcher<String> expected) {


### PR DESCRIPTION
The last version introduced a trailing comma after the fields generated by the
ContextPropertyConverter, even when there were no additional fields. This lead
to invalid JSON. This change fixes the problem.