### PR TITLE
Secure Log4j version in sample-spring-boot

### DIFF
--- a/sample-spring-boot/pom.xml
+++ b/sample-spring-boot/pom.xml
@@ -192,8 +192,46 @@
 			</activation>
 			<dependencies>
 				<dependency>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-api</artifactId>
+					<version>2.17.0</version>
+				</dependency>
+				<dependency>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-core</artifactId>
+					<version>2.17.0</version>
+				</dependency>
+				<dependency>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-slf4j-impl</artifactId>
+					<version>2.17.0</version>
+				</dependency>
+				<dependency>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-jul</artifactId>
+					<version>2.17.0</version>
+				</dependency>
+				<dependency>
 					<groupId>org.springframework.boot</groupId>
 					<artifactId>spring-boot-starter-log4j2</artifactId>
+					<exclusions>
+						<exclusion>
+							<groupId>org.apache.logging.log4j</groupId>
+							<artifactId>log4j-api</artifactId>
+						</exclusion>
+						<exclusion>
+							<groupId>org.apache.logging.log4j</groupId>
+							<artifactId>log4j-core</artifactId>
+						</exclusion>
+						<exclusion>
+							<groupId>org.apache.logging.log4j</groupId>
+							<artifactId>log4j-slf4j-impl</artifactId>
+						</exclusion>
+						<exclusion>
+							<groupId>org.apache.logging.log4j</groupId>
+							<artifactId>log4j-jul</artifactId>
+						</exclusion>
+					</exclusions>
 				</dependency>
 				<dependency>
 					<groupId>com.sap.hcp.cf.logging</groupId>


### PR DESCRIPTION
The currently latest spring-boot-starter-log4j2 uses log4j v 2.14.1,
which is vulnerable to several critical CVEs. This is addressed by
exclusion and explicit version targeting log4j 2.17.0

Signed-off-by: Karsten Schnitter <k.schnitter@sap.com>