### PR TITLE
#135 Fix UOE when using Custom Fields

### DIFF
--- a/cf-java-logging-support-log4j2/src/main/java/com/sap/hcp/cf/log4j2/converter/ContextPropsConverter.java
+++ b/cf-java-logging-support-log4j2/src/main/java/com/sap/hcp/cf/log4j2/converter/ContextPropsConverter.java
@@ -48,38 +48,38 @@ public class ContextPropsConverter extends LogEventPatternConverter {
 
     @Override
     public void format(LogEvent event, StringBuilder toAppendTo) {
-		Map<String, String> contextData = event.getContextData().toMap();
+        Map<String, String> contextData = event.getContextData().toMap();
         contextData = addCustomFieldsFromArguments(contextData, event);
         int lengthBefore = toAppendTo.length();
-		converter.convert(toAppendTo, contextData);
+        converter.convert(toAppendTo, contextData);
         // remove comma from pattern, when no properties are added
         // this is to avoid a double comma in the JSON
         // Do not do this on empty messages
         if (toAppendTo.length() == lengthBefore && lengthBefore > 0 && toAppendTo.charAt(lengthBefore - 1) == ',') {
             toAppendTo.setLength(lengthBefore - 1);
         }
-	}
+    }
 
     private Map<String, String> addCustomFieldsFromArguments(Map<String, String> contextData, LogEvent event) {
-		Message message = event.getMessage();
-		Object[] parameters = message.getParameters();
-		if (parameters == null) {
-			return contextData;
-		}
-		boolean unchangedContextData = true;
+        Message message = event.getMessage();
+        Object[] parameters = message.getParameters();
+        if (parameters == null) {
+            return contextData;
+        }
+        boolean unchangedContextData = true;
         Map<String, String> result = contextData;
-		for (Object current : parameters) {
-			if (current instanceof CustomField) {
-				CustomField field = (CustomField) current;
+        for (Object current: parameters) {
+            if (current instanceof CustomField) {
+                CustomField field = (CustomField) current;
                 if (unchangedContextData) {
                     // contextData might be an unmodifiable map
                     result = new HashMap<>(contextData);
                     unchangedContextData = false;
-				}
+                }
                 result.put(field.getKey(), field.getValue());
-			}
-		}
+            }
+        }
         return result;
-	}
+    }
 
 }


### PR DESCRIPTION
Log4j can provide different context data depending on its configuration.
In one case the provided context map is unmodifiable. In that case an
exception occurred, when a custom field was used as a message parameter.
This change guards against that issue, by defensively creating a modifiable
map of properties. Then the custom fields can be added safely.