### PR TITLE
Introduce JHM Benchmarking for Log Backends

### DIFF
--- a/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/log4j2/benchmark/BenchmarkRunner.java
+++ b/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/log4j2/benchmark/BenchmarkRunner.java
@@ -1,0 +1,15 @@
+package com.sap.hcp.cf.log4j2.benchmark;
+
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+public class BenchmarkRunner {
+
+    public static void main(String[] args) throws RunnerException {
+        Options options = new OptionsBuilder().include(EncodingBenchmarks.class.getSimpleName()).forks(1).build();
+        new Runner(options).run();
+    }
+
+}

--- a/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/log4j2/benchmark/EncodingBenchmarks.java
+++ b/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/log4j2/benchmark/EncodingBenchmarks.java
@@ -1,0 +1,78 @@
+package com.sap.hcp.cf.log4j2.benchmark;
+
+import static com.sap.hcp.cf.logging.common.request.RequestRecordBuilder.requestRecord;
+
+import java.io.PrintStream;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.util.NullOutputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import com.sap.hcp.cf.logging.common.Fields;
+import com.sap.hcp.cf.logging.common.Markers;
+import com.sap.hcp.cf.logging.common.customfields.CustomField;
+import com.sap.hcp.cf.logging.common.request.RequestRecord;
+
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
+public class EncodingBenchmarks {
+
+    public static Logger LOG = LoggerFactory.getLogger(EncodingBenchmarks.class);
+
+    @State(Scope.Benchmark)
+    public static class BenchmarkState {
+        private PrintStream out;
+
+        public String simpleLogMessage = "Simple message benchmark";
+        public CustomField customField = CustomField.customField("custom of ", CustomField.class.getSimpleName());
+        public String componentId = EncodingBenchmarks.class.getSimpleName();
+        public String requestLayer = "benchmark";
+
+        @Setup
+        public void substituteSystemOut() {
+            out = System.out;
+            System.setOut(new PrintStream(new NullOutputStream()));
+        }
+
+        @TearDown
+        public void resetSystemOut() {
+            System.setOut(out);
+        }
+    }
+
+    @Benchmark
+    public void simpleLog(BenchmarkState state) {
+        LOG.info(state.simpleLogMessage);
+    }
+
+    @Benchmark
+    public void singleCustomFieldFromArgument(BenchmarkState state) {
+        LOG.info(state.simpleLogMessage, state.customField);
+    }
+
+    @Benchmark
+    public void singleCommonFieldFromMdc(BenchmarkState state) {
+        MDC.put(Fields.COMPONENT_ID, state.componentId);
+        LOG.info(state.simpleLogMessage);
+        MDC.clear();
+    }
+
+    @Benchmark
+    public void minimalRequestRecord(BenchmarkState state) {
+        RequestRecord requestRecord = requestRecord(state.requestLayer).addContextTag(Fields.COMPONENT_ID,
+                                                                                      state.componentId).build();
+        requestRecord.start();
+        requestRecord.stop();
+        LOG.info(Markers.REQUEST_MARKER, "{}", requestRecord);
+    }
+
+}

--- a/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logback/benchmark/BenchmarkRunner.java
+++ b/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logback/benchmark/BenchmarkRunner.java
@@ -1,0 +1,15 @@
+package com.sap.hcp.cf.logback.benchmark;
+
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+public class BenchmarkRunner {
+
+    public static void main(String[] args) throws RunnerException {
+        Options options = new OptionsBuilder().include(EncodingBenchmarks.class.getSimpleName()).forks(1).build();
+        new Runner(options).run();
+    }
+
+}

--- a/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logback/benchmark/EncodingBenchmarks.java
+++ b/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logback/benchmark/EncodingBenchmarks.java
@@ -1,0 +1,78 @@
+package com.sap.hcp.cf.logback.benchmark;
+
+import static com.sap.hcp.cf.logging.common.request.RequestRecordBuilder.requestRecord;
+
+import java.io.PrintStream;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.util.NullOutputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import com.sap.hcp.cf.logging.common.Fields;
+import com.sap.hcp.cf.logging.common.Markers;
+import com.sap.hcp.cf.logging.common.customfields.CustomField;
+import com.sap.hcp.cf.logging.common.request.RequestRecord;
+
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
+public class EncodingBenchmarks {
+
+    public static Logger LOG = LoggerFactory.getLogger(EncodingBenchmarks.class);
+
+    @State(Scope.Benchmark)
+    public static class BenchmarkState {
+        private PrintStream out;
+
+        public String simpleLogMessage = "Simple message benchmark";
+        public CustomField customField = CustomField.customField("custom of ", CustomField.class.getSimpleName());
+        public String componentId = EncodingBenchmarks.class.getSimpleName();
+        public String requestLayer = "benchmark";
+
+        @Setup
+        public void substituteSystemOut() {
+            out = System.out;
+            System.setOut(new PrintStream(new NullOutputStream()));
+        }
+
+        @TearDown
+        public void resetSystemOut() {
+            System.setOut(out);
+        }
+    }
+
+    @Benchmark
+    public void simpleLog(BenchmarkState state) {
+        LOG.info(state.simpleLogMessage);
+    }
+
+    @Benchmark
+    public void singleCustomFieldFromArgument(BenchmarkState state) {
+        LOG.info(state.simpleLogMessage, state.customField);
+    }
+
+    @Benchmark
+    public void singleCommonFieldFromMdc(BenchmarkState state) {
+        MDC.put(Fields.COMPONENT_ID, state.componentId);
+        LOG.info(state.simpleLogMessage);
+        MDC.clear();
+    }
+
+    @Benchmark
+    public void minimalRequestRecord(BenchmarkState state) {
+        RequestRecord requestRecord = requestRecord(state.requestLayer).addContextTag(Fields.COMPONENT_ID,
+                                                                                      state.componentId).build();
+        requestRecord.start();
+        requestRecord.stop();
+        LOG.info(Markers.REQUEST_MARKER, "{}", requestRecord);
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <junit.version>4.13.2</junit.version>
         <mockito.version>1.9.5</mockito.version>
+        <jmh.version>1.34</jmh.version>
         <surefire.plugin.version>2.18.1</surefire.plugin.version>
         <animal.sniffer.version>1.19</animal.sniffer.version>
         <exec.plugin.version>1.4.0</exec.plugin.version>
@@ -221,6 +222,18 @@
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-core</artifactId>
+			<version>${jmh.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-generator-annprocess</artifactId>
+			<version>${jmh.version}</version>
+			<scope>test</scope>
+		</dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
Changes to the JSON encoding and messages generation overall may impact
the library performance and with this the application performance. To provide
a toolset to measure impact of changes in future, the Java Microbenchmarking
Harness (JMH) was introduce with a few simple benchmarks. The are
implemented separately for log4j2 and logback. The current results from my
machine are as follow:

Logback:

```
Benchmark                                          Mode  Cnt       Score       Error  Units
EncodingBenchmarks.minimalRequestRecord           thrpt    5   84562,416 ±  8912,890  ops/s
EncodingBenchmarks.simpleLog                      thrpt    5  115365,061 ± 15645,826  ops/s
EncodingBenchmarks.singleCommonFieldFromMdc       thrpt    5  113844,805 ±  3235,766  ops/s
EncodingBenchmarks.singleCustomFieldFromArgument  thrpt    5  109952,525 ±  9775,466  ops/s
``` 

Log4j2:

```
Benchmark                                          Mode  Cnt       Score       Error  Units
EncodingBenchmarks.minimalRequestRecord           thrpt    5  114756,173 ±  7212,135  ops/s
EncodingBenchmarks.simpleLog                      thrpt    5  170957,170 ±  2546,579  ops/s
EncodingBenchmarks.singleCommonFieldFromMdc       thrpt    5  164589,191 ± 29621,024  ops/s
EncodingBenchmarks.singleCustomFieldFromArgument  thrpt    5  173940,242 ± 24513,865  ops/s
```
Signed-off-by: Karsten Schnitter <k.schnitter@sap.com>