### PR TITLE
Add support for W3C traceparent HTTP header

### DIFF
--- a/cf-java-logging-support-core/beats/app-logs/docs/fields.asciidoc
+++ b/cf-java-logging-support-core/beats/app-logs/docs/fields.asciidoc
@@ -91,6 +91,19 @@ required: False
 A unique identifier that can be used to correlate multiple messages to a request.
 
 
+==== w3c_traceparent
+
+type: string
+
+example: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01
+
+required: False
+
+The content of the W3C traceparent header as defined in 
+https://www.w3.org/TR/trace-context/#traceparent-header.
+The traceparent allows correlation of logs to the request.
+
+
 ==== sap_passport
 
 type: string

--- a/cf-java-logging-support-core/beats/app-logs/etc/app-logs.template.json
+++ b/cf-java-logging-support-core/beats/app-logs/etc/app-logs.template.json
@@ -198,6 +198,11 @@
           "index": "not_analyzed",
           "type": "string"
         },
+        "w3c_traceparent": {
+          "doc_values": true,
+          "index": "not_analyzed",
+          "type": "string"
+        },
         "written_at": {
           "doc_values": true,
           "ignore_malformed": true,

--- a/cf-java-logging-support-core/beats/app-logs/etc/fields.yml
+++ b/cf-java-logging-support-core/beats/app-logs/etc/fields.yml
@@ -76,6 +76,15 @@ ctx:
       description: |
         A unique identifier that can be used to correlate multiple messages to a request.
 
+    - name: "w3c_traceparent"
+      type: string
+      required: false
+      example: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+      description: |
+        The content of the W3C traceparent header as defined in 
+        https://www.w3.org/TR/trace-context/#traceparent-header.
+        The traceparent allows correlation of logs to the request.
+
     - name: "sap_passport"
       type: string
       required: false

--- a/cf-java-logging-support-core/beats/request-metrics/docs/fields.asciidoc
+++ b/cf-java-logging-support-core/beats/request-metrics/docs/fields.asciidoc
@@ -100,6 +100,19 @@ required: False
 A unique identifier that can be used to correlate multiple messages to a request.
 
 
+==== w3c_traceparent
+
+type: string
+
+example: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01
+
+required: False
+
+The content of the W3C traceparent header as defined in 
+https://www.w3.org/TR/trace-context/#traceparent-header.
+The traceparent allows correlation of logs to the request.
+
+
 ==== sap_passport
 
 type: string

--- a/cf-java-logging-support-core/beats/request-metrics/etc/fields.yml
+++ b/cf-java-logging-support-core/beats/request-metrics/etc/fields.yml
@@ -85,6 +85,15 @@ ctx:
       description: |
         A unique identifier that can be used to correlate multiple messages to a request.
 
+    - name: "w3c_traceparent"
+      type: string
+      required: false
+      example: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+      description: |
+        The content of the W3C traceparent header as defined in 
+        https://www.w3.org/TR/trace-context/#traceparent-header.
+        The traceparent allows correlation of logs to the request.
+
     - name: "sap_passport"
       type: string
       required: false

--- a/cf-java-logging-support-core/beats/request-metrics/etc/request-metrics.template.json
+++ b/cf-java-logging-support-core/beats/request-metrics/etc/request-metrics.template.json
@@ -263,6 +263,11 @@
           "index": "not_analyzed",
           "type": "string"
         },
+        "w3c_traceparent": {
+          "doc_values": true,
+          "index": "not_analyzed",
+          "type": "string"
+        },
         "written_at": {
           "doc_values": true,
           "ignore_malformed": true,

--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/Fields.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/Fields.java
@@ -13,6 +13,7 @@ public interface Fields {
   public String WRITTEN_TS = "written_ts";
   public String CORRELATION_ID = "correlation_id";
   public String REQUEST_ID = "request_id";
+  public String W3C_TRACEPARENT = "w3c_traceparent";
   public String SAP_PASSPORT = "sap_passport";
   public String SAP_PASSPORT_ACTION = "sap_passport_Action";
   public String SAP_PASSPORT_ACTIONTYPE = "sap_passport_ActionType";

--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/request/HttpHeaders.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/request/HttpHeaders.java
@@ -36,6 +36,7 @@ public enum HttpHeaders implements HttpHeader {
                                                X_VCAP_REQUEST_ID("x-vcap-request-id", Fields.REQUEST_ID, true), //
                                                CORRELATION_ID("X-CorrelationID", Fields.CORRELATION_ID, true,
                                                               X_VCAP_REQUEST_ID), //
+                                               W3C_TRACEPARENT("traceparent", Fields.W3C_TRACEPARENT, true),
                                                SAP_PASSPORT("sap-passport", Fields.SAP_PASSPORT, true), //
                                                TENANT_ID("tenantid", Fields.TENANT_ID, true); //
 

--- a/cf-java-logging-support-core/src/test/java/com/sap/hcp/cf/logging/common/request/HttpHeadersTest.java
+++ b/cf-java-logging-support-core/src/test/java/com/sap/hcp/cf/logging/common/request/HttpHeadersTest.java
@@ -24,7 +24,7 @@ public class HttpHeadersTest {
 
     @Test
     public void hasCorrectNumberOfTypes() throws Exception {
-        assertThat(HttpHeaders.values().length, is(equalTo(19)));
+        assertThat(HttpHeaders.values().length, is(equalTo(20)));
     }
 
     @Test
@@ -34,6 +34,7 @@ public class HttpHeadersTest {
         assertThat(HttpHeaders.CORRELATION_ID.getName(), is("X-CorrelationID"));
         assertThat(HttpHeaders.REFERER.getName(), is("referer"));
         assertThat(HttpHeaders.TENANT_ID.getName(), is("tenantid"));
+        assertThat(HttpHeaders.W3C_TRACEPARENT.getName(), is("traceparent"));
         assertThat(HttpHeaders.X_CUSTOM_HOST.getName(), is("x-custom-host"));
         assertThat(HttpHeaders.X_FORWARDED_FOR.getName(), is("x-forwarded-for"));
         assertThat(HttpHeaders.X_FORWARDED_HOST.getName(), is("x-forwarded-host"));
@@ -56,6 +57,7 @@ public class HttpHeadersTest {
         assertThat(HttpHeaders.CORRELATION_ID.getField(), is(Fields.CORRELATION_ID));
         assertThat(HttpHeaders.REFERER.getField(), is(nullValue()));
         assertThat(HttpHeaders.TENANT_ID.getField(), is(Fields.TENANT_ID));
+        assertThat(HttpHeaders.W3C_TRACEPARENT.getField(), is(Fields.W3C_TRACEPARENT));
         assertThat(HttpHeaders.X_CUSTOM_HOST.getField(), is(Fields.X_CUSTOM_HOST));
         assertThat(HttpHeaders.X_FORWARDED_FOR.getField(), is(Fields.X_FORWARDED_FOR));
         assertThat(HttpHeaders.X_FORWARDED_HOST.getField(), is(Fields.X_FORWARDED_HOST));
@@ -93,6 +95,7 @@ public class HttpHeadersTest {
         assertThat(HttpHeaders.CORRELATION_ID.getAliases(), containsInAnyOrder(HttpHeaders.X_VCAP_REQUEST_ID));
         assertThat(HttpHeaders.REFERER.getAliases(), is(empty()));
         assertThat(HttpHeaders.TENANT_ID.getAliases(), is(empty()));
+        assertThat(HttpHeaders.W3C_TRACEPARENT.getAliases(), is(empty()));
         assertThat(HttpHeaders.X_CUSTOM_HOST.getAliases(), is(empty()));
         assertThat(HttpHeaders.X_FORWARDED_FOR.getAliases(), is(empty()));
         assertThat(HttpHeaders.X_FORWARDED_HOST.getAliases(), is(empty()));
@@ -111,7 +114,8 @@ public class HttpHeadersTest {
     @Test
     public void propagatesCorrectHeaders() throws Exception {
         assertThat(HttpHeaders.propagated(), containsInAnyOrder(HttpHeaders.CORRELATION_ID, HttpHeaders.SAP_PASSPORT,
-                                                                HttpHeaders.TENANT_ID, HttpHeaders.X_VCAP_REQUEST_ID));
+                                                                HttpHeaders.TENANT_ID, HttpHeaders.W3C_TRACEPARENT,
+                                                                HttpHeaders.X_VCAP_REQUEST_ID));
     }
 
 }

--- a/cf-java-logging-support-servlet/src/test/java/com/sap/hcp/cf/logging/servlet/filter/RequestLogTest.java
+++ b/cf-java-logging-support-servlet/src/test/java/com/sap/hcp/cf/logging/servlet/filter/RequestLogTest.java
@@ -139,6 +139,19 @@ public class RequestLogTest {
         }
     }
 
+    @Test
+    public void logsW3cTraceparentFromRequestHeader() throws Exception {
+        String traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        HttpGet get = createRequestWithHeader(HttpHeaders.W3C_TRACEPARENT.getName(), traceparent);
+        try (CloseableHttpResponse response = client.execute(get)) {
+            assertThat("Application log without traceparent.", getRequestMessage(), hasEntry(Fields.W3C_TRACEPARENT,
+                                                                                             traceparent));
+            assertThat("Request log without traceparent.", getRequestLog(), hasEntry(Fields.W3C_TRACEPARENT,
+                                                                                     traceparent));
+        }
+
+    }
+
 	@Test
 	public void writesCorrelationIdFromHeadersAsResponseHeader() throws Exception {
 		String correlationId = UUID.randomUUID().toString();

--- a/cf-java-logging-support-servlet/src/test/java/com/sap/hcp/cf/logging/servlet/filter/RequestLoggingFilterTest.java
+++ b/cf-java-logging-support-servlet/src/test/java/com/sap/hcp/cf/logging/servlet/filter/RequestLoggingFilterTest.java
@@ -47,6 +47,7 @@ public class RequestLoggingFilterTest {
     private static final String REQUEST_ID = "1234-56-7890-xxx";
     private static final String CORRELATION_ID = "xxx-56-7890-xxx";
     private static final String TENANT_ID = "tenant1";
+    private static final String W3C_TRACEPARENT = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
     private static final String REQUEST = "/foobar";
     private static final String QUERY_STRING = "baz=bla";
     private static final String FULL_REQUEST = REQUEST + "?" + QUERY_STRING;
@@ -209,6 +210,14 @@ public class RequestLoggingFilterTest {
         assertThat(getField(Fields.CORRELATION_ID), not(REQUEST_ID));
         assertThat(getField(Fields.REQUEST_ID), is(REQUEST_ID));
         assertThat(getField(Fields.TENANT_ID), is(nullValue()));
+    }
+
+    @Test
+    public void testExplicitW3cTraceparent() throws IOException, ServletException {
+        mockGetHeader(HttpHeaders.W3C_TRACEPARENT, W3C_TRACEPARENT);
+        FilterChain mockFilterChain = mock(FilterChain.class);
+        new RequestLoggingFilter().doFilter(mockReq, mockResp, mockFilterChain);
+        assertThat(getField(Fields.W3C_TRACEPARENT), is(W3C_TRACEPARENT));
     }
 
     @Test


### PR DESCRIPTION
The contents of the HTTP header "traceparent" is extracted and logged
with every log event in field "w3c_traceparent". This is done for regular
application log messages and request logs. The feature allows correlation
of log messages with requests and possible traces.

Signed-off-by: Karsten Schnitter <k.schnitter@sap.com>