### PR TITLE
Add Thread name to JSON log events

### DIFF
--- a/cf-java-logging-support-log4j2/src/main/java/com/sap/hcp/cf/log4j2/layout/supppliers/BaseFieldSupplier.java
+++ b/cf-java-logging-support-log4j2/src/main/java/com/sap/hcp/cf/log4j2/layout/supppliers/BaseFieldSupplier.java
@@ -20,6 +20,7 @@ public class BaseFieldSupplier implements Log4jContextFieldSupplier {
         fields.put(Fields.TYPE, LogEventUtilities.isRequestLog(event) ? Defaults.TYPE_REQUEST : Defaults.TYPE_LOG);
         fields.put(Fields.LEVEL, String.valueOf(event.getLevel()));
         fields.put(Fields.LOGGER, event.getLoggerName());
+        fields.put(Fields.THREAD, event.getThreadName());
         if (!LogEventUtilities.isRequestLog(event) && event.getMessage() != null) {
             fields.put(Fields.MSG, LogEventUtilities.getFormattedMessage(event));
         }

--- a/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/logging/common/TestAppLog.java
+++ b/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/logging/common/TestAppLog.java
@@ -34,6 +34,8 @@ public class TestAppLog extends AbstractTest {
         assertThat(getField(Fields.COMPONENT_NAME), is(nullValue()));
         assertThat(getField(Fields.COMPONENT_INSTANCE), is(nullValue()));
         assertThat(getField(Fields.WRITTEN_TS), is(notNullValue()));
+        assertThat(getField(Fields.LOGGER), is(TestAppLog.class.getName()));
+        assertThat(getField(Fields.THREAD), is(Thread.currentThread().getName()));
     }
 
     @Test

--- a/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/encoder/BaseFieldSupplier.java
+++ b/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/encoder/BaseFieldSupplier.java
@@ -21,6 +21,7 @@ public class BaseFieldSupplier implements LogbackContextFieldSupplier {
         fields.put(Fields.TYPE, isRequestLog(event) ? Defaults.TYPE_REQUEST : Defaults.TYPE_LOG);
         fields.put(Fields.LEVEL, String.valueOf(event.getLevel()));
         fields.put(Fields.LOGGER, event.getLoggerName());
+        fields.put(Fields.THREAD, event.getThreadName());
         if (!isRequestLog(event)) {
             fields.put(Fields.MSG, event.getFormattedMessage());
         }

--- a/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logging/common/TestAppLog.java
+++ b/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logging/common/TestAppLog.java
@@ -34,6 +34,8 @@ public class TestAppLog extends AbstractTest {
         assertThat(getField(Fields.COMPONENT_NAME), is("-"));
         assertThat(getField(Fields.COMPONENT_INSTANCE), is("0"));
         assertThat(getField(Fields.WRITTEN_TS), is(notNullValue()));
+        assertThat(getField(Fields.LOGGER), is(TestAppLog.class.getName()));
+        assertThat(getField(Fields.THREAD), is(Thread.currentThread().getName()));
         assertThat(getField(Fields.CATEGORIES), is(notNullValue()));
     }
 


### PR DESCRIPTION
This field was accidentally dropped in v3.6.0. Test cases were changed to ensure proper behaviour.

Signed-off-by: Karsten Schnitter <k.schnitter@sap.com>