### PR TITLE
Add a new servlet logging module supporting jakarta.* packages.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,3 @@ gen
 
 # VSCode
 .vscode
-
-cf-java-logging-support-servlet-jakarta/src

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ gen
 
 # VSCode
 .vscode
+
+cf-java-logging-support-servlet-jakarta/src

--- a/cf-java-logging-support-servlet-jakarta/pom.xml
+++ b/cf-java-logging-support-servlet-jakarta/pom.xml
@@ -99,7 +99,7 @@
 									<classifier>sources</classifier>
 									<overWrite>false</overWrite>
 									<outputDirectory>target/generated-sources/java</outputDirectory>
-									<includes>**/*.java</includes>
+									<includes>**/*.*</includes>
 								</artifactItem>
 								<artifactItem>
 									<groupId>${project.groupId}</groupId>
@@ -109,7 +109,7 @@
 									<classifier>test-sources</classifier>
 									<overWrite>false</overWrite>
 									<outputDirectory>target/generated-test-sources/java</outputDirectory>
-									<includes>**/*.java</includes>
+									<includes>**/*.*</includes>
 								</artifactItem>
 							</artifactItems>
 						</configuration>

--- a/cf-java-logging-support-servlet-jakarta/pom.xml
+++ b/cf-java-logging-support-servlet-jakarta/pom.xml
@@ -99,7 +99,7 @@
 									<classifier>sources</classifier>
 									<overWrite>false</overWrite>
 									<outputDirectory>target/generated-sources/java</outputDirectory>
-									<includes>**/*.*</includes>
+									<includes>**/*.java</includes>
 								</artifactItem>
 								<artifactItem>
 									<groupId>${project.groupId}</groupId>
@@ -109,7 +109,7 @@
 									<classifier>test-sources</classifier>
 									<overWrite>false</overWrite>
 									<outputDirectory>target/generated-test-sources/java</outputDirectory>
-									<includes>**/*.*</includes>
+									<includes>**/*.java,**/*.xml</includes>
 								</artifactItem>
 							</artifactItems>
 						</configuration>

--- a/cf-java-logging-support-servlet-jakarta/pom.xml
+++ b/cf-java-logging-support-servlet-jakarta/pom.xml
@@ -80,19 +80,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<artifactId>maven-clean-plugin</artifactId>
-				<version>3.2.0</version>
-				<configuration>
-					<filesets>
-						<fileset>
-							<directory>${basedir}/src</directory>
-							<followSymlinks>false</followSymlinks>
-						</fileset>
-					</filesets>
-				</configuration>
-			</plugin>
-
-			<plugin>
 				<artifactId>maven-dependency-plugin</artifactId>
 				<version>3.5.0</version>
 				<executions>
@@ -111,7 +98,7 @@
 									<type>jar</type>
 									<classifier>sources</classifier>
 									<overWrite>false</overWrite>
-									<outputDirectory>${basedir}/src/main/java</outputDirectory>
+									<outputDirectory>target/generated-sources/java</outputDirectory>
 									<includes>**/*.java</includes>
 								</artifactItem>
 								<artifactItem>
@@ -121,10 +108,70 @@
 									<type>jar</type>
 									<classifier>test-sources</classifier>
 									<overWrite>false</overWrite>
-									<outputDirectory>${basedir}/src/test/java</outputDirectory>
+									<outputDirectory>target/generated-test-sources/java</outputDirectory>
 									<includes>**/*.java</includes>
 								</artifactItem>
 							</artifactItems>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>3.3.0</version>
+				<executions>
+					<execution>
+						<id>add-generated-sources</id>
+						<goals>
+							<goal>add-source</goal>
+						</goals>
+						<phase>generate-sources</phase>
+						<configuration>
+							<sources>
+								<source>target/generated-sources/java</source>
+							</sources>
+						</configuration>
+					</execution>
+					<execution>
+						<id>add-generated-resources</id>
+						<goals>
+							<goal>add-resource</goal>
+						</goals>
+						<phase>generate-resources</phase>
+						<configuration>
+							<resources>
+								<resource>
+									<directory>target/generated-sources/resources</directory>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+					<execution>
+						<id>add-generated-test-sources</id>
+						<goals>
+							<goal>add-test-source</goal>
+						</goals>
+						<phase>generate-test-sources</phase>
+						<configuration>
+							<sources>
+								<source>target/generated-test-sources/java</source>
+							</sources>
+						</configuration>
+					</execution>
+					<execution>
+						<id>add-generated-test-resources</id>
+						<goals>
+							<goal>add-test-resource</goal>
+						</goals>
+						<phase>generate-test-resources</phase>
+						<configuration>
+							<resources>
+								<resource>
+									<directory>target/generated-test-sources/resources</directory>
+								</resource>
+							</resources>
 						</configuration>
 					</execution>
 				</executions>
@@ -135,36 +182,36 @@
 				<artifactId>find-and-replace-maven-plugin</artifactId>
 				<version>1.1.0</version>
 				<executions>
-				   <execution>
-					  <id>replace-in-xml</id>
-					  <phase>process-resources</phase>
-					  <goals>
-						 <goal>find-and-replace</goal>
-					  </goals>
-					  <configuration>
-						 <replacementType>file-contents</replacementType>
-						 <baseDir>src/</baseDir>
-						 <findRegex>javax.servlet</findRegex>
-						 <replaceValue>jakarta.servlet</replaceValue>
-						 <recursive>true</recursive>
-						 <fileMask>.xml</fileMask>
-					  </configuration>
-				   </execution>
-				   <execution>
-					  <id>replace-in-java</id>
-					  <phase>process-resources</phase>
-					  <goals>
-						 <goal>find-and-replace</goal>
-					  </goals>
-					  <configuration>
-						 <replacementType>file-contents</replacementType>
-						 <baseDir>src/</baseDir>
-						 <findRegex>javax.servlet</findRegex>
-						 <replaceValue>jakarta.servlet</replaceValue>
-						 <recursive>true</recursive>
-						 <fileMask>.java</fileMask>
-					  </configuration>
-				   </execution>
+					<execution>
+						<id>replace-in-sources</id>
+						<phase>process-sources</phase>
+						<goals>
+							<goal>find-and-replace</goal>
+						</goals>
+						<configuration>
+							<replacementType>file-contents</replacementType>
+							<baseDir>target/generated-sources/java/</baseDir>
+							<findRegex>javax.servlet</findRegex>
+							<replaceValue>jakarta.servlet</replaceValue>
+							<recursive>true</recursive>
+							<fileMask>.java</fileMask>
+						</configuration>
+					</execution>
+					<execution>
+						<id>replace-in-test-sources</id>
+						<phase>process-sources</phase>
+						<goals>
+							<goal>find-and-replace</goal>
+						</goals>
+						<configuration>
+							<replacementType>file-contents</replacementType>
+							<baseDir>target/generated-test-sources/java/</baseDir>
+							<findRegex>javax.servlet</findRegex>
+							<replaceValue>jakarta.servlet</replaceValue>
+							<recursive>true</recursive>
+							<fileMask>.java</fileMask>
+						</configuration>
+					</execution>
 				</executions>
 			</plugin>
 

--- a/cf-java-logging-support-servlet-jakarta/pom.xml
+++ b/cf-java-logging-support-servlet-jakarta/pom.xml
@@ -127,7 +127,6 @@
 						<goals>
 							<goal>add-source</goal>
 						</goals>
-						<phase>generate-sources</phase>
 						<configuration>
 							<sources>
 								<source>target/generated-sources/java</source>
@@ -135,43 +134,14 @@
 						</configuration>
 					</execution>
 					<execution>
-						<id>add-generated-resources</id>
-						<goals>
-							<goal>add-resource</goal>
-						</goals>
-						<phase>generate-resources</phase>
-						<configuration>
-							<resources>
-								<resource>
-									<directory>target/generated-sources/resources</directory>
-								</resource>
-							</resources>
-						</configuration>
-					</execution>
-					<execution>
 						<id>add-generated-test-sources</id>
 						<goals>
 							<goal>add-test-source</goal>
 						</goals>
-						<phase>generate-test-sources</phase>
 						<configuration>
 							<sources>
 								<source>target/generated-test-sources/java</source>
 							</sources>
-						</configuration>
-					</execution>
-					<execution>
-						<id>add-generated-test-resources</id>
-						<goals>
-							<goal>add-test-resource</goal>
-						</goals>
-						<phase>generate-test-resources</phase>
-						<configuration>
-							<resources>
-								<resource>
-									<directory>target/generated-test-sources/resources</directory>
-								</resource>
-							</resources>
 						</configuration>
 					</execution>
 				</executions>

--- a/cf-java-logging-support-servlet-jakarta/pom.xml
+++ b/cf-java-logging-support-servlet-jakarta/pom.xml
@@ -141,7 +141,6 @@
 						<goals>
 							<goal>add-source</goal>
 						</goals>
-						<phase>generate-sources</phase>
 						<configuration>
 							<sources>
 								<source>target/generated-sources/java</source>
@@ -153,7 +152,6 @@
 						<goals>
 							<goal>add-test-source</goal>
 						</goals>
-						<phase>generate-test-sources</phase>
 						<configuration>
 							<sources>
 								<source>target/generated-test-sources/java</source>
@@ -165,7 +163,6 @@
 						<goals>
 							<goal>add-test-resource</goal>
 						</goals>
-						<phase>generate-test-resources</phase>
 						<configuration>
 							<resources>
 								<resource>

--- a/cf-java-logging-support-servlet-jakarta/pom.xml
+++ b/cf-java-logging-support-servlet-jakarta/pom.xml
@@ -93,20 +93,8 @@
 	<build>
 		<plugins>
 			<plugin>
-				<artifactId>maven-source-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>attach-sources</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-
-			<!-- ENSURE SOURCES ARE UPDATED -->
-			<plugin>
 				<artifactId>maven-clean-plugin</artifactId>
+				<version>3.2.0</version>
 				<configuration>
 					<filesets>
 						<fileset>
@@ -117,9 +105,9 @@
 				</configuration>
 			</plugin>
 
-			<!-- EXTRACT SOURCES TO SRC DIRECTORY TO ENABLE ECLIPSE -->
 			<plugin>
 				<artifactId>maven-dependency-plugin</artifactId>
+				<version>3.5.0</version>
 				<executions>
 					<execution>
 						<id>unpack</id>

--- a/cf-java-logging-support-servlet-jakarta/pom.xml
+++ b/cf-java-logging-support-servlet-jakarta/pom.xml
@@ -1,0 +1,206 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>cf-java-logging-support-servlet-jakarta</artifactId>
+	<packaging>jar</packaging>
+
+	<name>cf-java-logging-support-servlet-jakarta</name>
+	<parent>
+		<groupId>com.sap.hcp.cf.logging</groupId>
+		<artifactId>cf-java-logging-support-parent</artifactId>
+		<version>3.6.3</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<properties>
+		<servlet.api.version>5.0.0</servlet.api.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>com.sap.hcp.cf.logging</groupId>
+			<artifactId>cf-java-logging-support-servlet</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.sap.hcp.cf.logging</groupId>
+			<artifactId>cf-java-logging-support-servlet</artifactId>
+			<version>${project.version}</version>
+			<classifier>tests</classifier>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- servlet api -->
+		<dependency>
+			<groupId>jakarta.servlet</groupId>
+			<artifactId>jakarta.servlet-api</artifactId>
+			<version>${servlet.api.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.sap.hcp.cf.logging</groupId>
+			<artifactId>cf-java-logging-support-core</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<!-- we need our logback implementation for testing! -->
+		<dependency>
+			<groupId>com.sap.hcp.cf.logging</groupId>
+			<artifactId>cf-java-logging-support-logback</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>${logback.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<!-- Library for token signing/verification -->
+		<dependency>
+			<groupId>com.auth0</groupId>
+			<artifactId>java-jwt</artifactId>
+			<version>3.18.2</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.13.4.1</version>
+		</dependency>
+
+		<!-- testing -->
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-server</artifactId>
+			<version>11.0.13</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-servlet</artifactId>
+			<version>11.0.13</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>4.5.13</version>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-source-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<!-- ENSURE SOURCES ARE UPDATED -->
+			<plugin>
+				<artifactId>maven-clean-plugin</artifactId>
+				<configuration>
+					<filesets>
+						<fileset>
+							<directory>${basedir}/src</directory>
+							<followSymlinks>false</followSymlinks>
+						</fileset>
+					</filesets>
+				</configuration>
+			</plugin>
+
+			<!-- EXTRACT SOURCES TO SRC DIRECTORY TO ENABLE ECLIPSE -->
+			<plugin>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>unpack</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>unpack</goal>
+						</goals>
+						<configuration>
+							<artifactItems>
+								<artifactItem>
+									<groupId>${project.groupId}</groupId>
+									<artifactId>cf-java-logging-support-servlet</artifactId>
+									<version>${project.version}</version>
+									<type>jar</type>
+									<classifier>sources</classifier>
+									<overWrite>false</overWrite>
+									<outputDirectory>${basedir}/src/main/java</outputDirectory>
+									<includes>**/*.java</includes>
+								</artifactItem>
+								<artifactItem>
+									<groupId>${project.groupId}</groupId>
+									<artifactId>cf-java-logging-support-servlet</artifactId>
+									<version>${project.version}</version>
+									<type>jar</type>
+									<classifier>test-sources</classifier>
+									<overWrite>false</overWrite>
+									<outputDirectory>${basedir}/src/test/java</outputDirectory>
+									<includes>**/*.java</includes>
+								</artifactItem>
+							</artifactItems>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>io.github.floverfelt</groupId>
+				<artifactId>find-and-replace-maven-plugin</artifactId>
+				<version>1.1.0</version>
+				<executions>
+				   <execution>
+					  <id>replace-in-xml</id>
+					  <phase>process-resources</phase>
+					  <goals>
+						 <goal>find-and-replace</goal>
+					  </goals>
+					  <configuration>
+						 <replacementType>file-contents</replacementType>
+						 <baseDir>src/</baseDir>
+						 <findRegex>javax.servlet</findRegex>
+						 <replaceValue>jakarta.servlet</replaceValue>
+						 <recursive>true</recursive>
+						 <fileMask>.xml</fileMask>
+					  </configuration>
+				   </execution>
+				   <execution>
+					  <id>replace-in-java</id>
+					  <phase>process-resources</phase>
+					  <goals>
+						 <goal>find-and-replace</goal>
+					  </goals>
+					  <configuration>
+						 <replacementType>file-contents</replacementType>
+						 <baseDir>src/</baseDir>
+						 <findRegex>javax.servlet</findRegex>
+						 <replaceValue>jakarta.servlet</replaceValue>
+						 <recursive>true</recursive>
+						 <fileMask>.java</fileMask>
+					  </configuration>
+				   </execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>animal-sniffer-maven-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+		</plugin>
+
+		</plugins>
+	</build>
+</project>

--- a/cf-java-logging-support-servlet-jakarta/pom.xml
+++ b/cf-java-logging-support-servlet-jakarta/pom.xml
@@ -109,7 +109,7 @@
 									<classifier>test-sources</classifier>
 									<overWrite>false</overWrite>
 									<outputDirectory>target/generated-test-sources/java</outputDirectory>
-									<includes>**/*.java,**/*.xml</includes>
+									<includes>**/*.java,**/logback-test.xml</includes>
 								</artifactItem>
 							</artifactItems>
 						</configuration>

--- a/cf-java-logging-support-servlet-jakarta/pom.xml
+++ b/cf-java-logging-support-servlet-jakarta/pom.xml
@@ -174,7 +174,7 @@
 				<configuration>
 					<skip>true</skip>
 				</configuration>
-		</plugin>
+			</plugin>
 
 		</plugins>
 	</build>

--- a/cf-java-logging-support-servlet-jakarta/pom.xml
+++ b/cf-java-logging-support-servlet-jakarta/pom.xml
@@ -16,21 +16,8 @@
 	<properties>
 		<servlet.api.version>5.0.0</servlet.api.version>
 	</properties>
-	<dependencies>
-		<dependency>
-			<groupId>com.sap.hcp.cf.logging</groupId>
-			<artifactId>cf-java-logging-support-servlet</artifactId>
-			<version>${project.version}</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.sap.hcp.cf.logging</groupId>
-			<artifactId>cf-java-logging-support-servlet</artifactId>
-			<version>${project.version}</version>
-			<classifier>tests</classifier>
-			<scope>provided</scope>
-		</dependency>
 
+	<dependencies>
 		<!-- servlet api -->
 		<dependency>
 			<groupId>jakarta.servlet</groupId>
@@ -60,12 +47,12 @@
 		<dependency>
 			<groupId>com.auth0</groupId>
 			<artifactId>java-jwt</artifactId>
-			<version>3.18.2</version>
+			<version>${java-jwt.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.13.4.1</version>
+			<version>${jackson-databind.version}</version>
 		</dependency>
 
 		<!-- testing -->
@@ -84,7 +71,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.5.13</version>
+			<version>${httpclient.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/cf-java-logging-support-servlet/pom.xml
+++ b/cf-java-logging-support-servlet/pom.xml
@@ -76,4 +76,20 @@
 		</dependency>
 
 	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-source-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>jar</goal>
+							<goal>test-jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/cf-java-logging-support-servlet/pom.xml
+++ b/cf-java-logging-support-servlet/pom.xml
@@ -47,12 +47,12 @@
 		<dependency>
 			<groupId>com.auth0</groupId>
 			<artifactId>java-jwt</artifactId>
-			<version>3.18.2</version>
+			<version>${java-jwt.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.13.4.1</version>
+			<version>${jackson-databind.version}</version>
 		</dependency>
 
 		<!-- testing -->
@@ -71,7 +71,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.5.13</version>
+			<version>${httpclient.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,9 @@
         <javadoc.plugin.version>3.1.1</javadoc.plugin.version>
         <gpg.plugin.version>1.6</gpg.plugin.version>
         <maven.compiler.release>8</maven.compiler.release>
+        <java-jwt.version>3.18.2</java-jwt.version>
+        <jackson-databind.version>2.13.4.1</jackson-databind.version>
+        <httpclient.version>4.5.13</httpclient.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,7 @@
         <module>cf-java-logging-support-logback</module>
         <module>cf-java-logging-support-log4j2</module>
         <module>cf-java-logging-support-servlet</module>
+        <module>cf-java-logging-support-servlet-jakarta</module>
         <module>cf-java-logging-support-jersey</module>
         <module>cf-java-monitoring-custom-metrics-clients</module>
         <module>sample</module>


### PR DESCRIPTION
The latest version 3.6.3  of `cf-java-logging-support-servlet` is not compatible with the [Jakarta Servlet API](https://jakarta.ee/specifications/servlet/). The Jakarta Servlet API is also used by the new [Spring Framework 6](https://spring.io/blog/2021/09/02/a-java-17-and-jakarta-ee-9-baseline-for-spring-framework-6).
This PR adds a new module `cf-java-logging-support-servlet-jakarta` which supports the jakarta servlet API. This PR copies the source and test-source code of module `cf-java-logging-support-servlet` to the new module. Then it replaces the packages `javax.*` with `jakarta.*` and performs the tests.