### PR TITLE
Use the SAP Java buildpack

### DIFF
--- a/sample/manifest.yml
+++ b/sample/manifest.yml
@@ -5,8 +5,9 @@ applications:
 #
 - name: logging-sample-app
   instances: 1
-  memory: 592M
-  disk_quota: 140M
+  buildpack: sap_java_buildpack
+  memory: 256M
+  disk_quota: 256M
   path: target/logging-sample-app-3.7.0.war
   env:
     RANDOM_SLEEP: true
@@ -14,3 +15,7 @@ applications:
     LOG_SENSITIVE_CONNECTION_DATA: false
     LOG_REMOTE_USER: false
     LOG_REFERER: false
+    # Some defaults in the SAP Java buildpack much higher than what this app needs.
+    # The values below have been devised empirically
+    JAVA_OPTS: '-XX:ReservedCodeCacheSize=40M -XX:MaxMetaspaceSize=28M -Xss256K'
+    # Default: '-XX:ReservedCodeCacheSize=240M -XX:MaxMetaspaceSize=141152K -Xss1M'

--- a/sample/manifest.yml
+++ b/sample/manifest.yml
@@ -5,6 +5,8 @@ applications:
 #
 - name: logging-sample-app
   instances: 1
+  memory: 592M
+  disk_quota: 140M
   path: target/logging-sample-app-3.7.0.war
   env:
     RANDOM_SLEEP: true


### PR DESCRIPTION
By using the SAP Java buildpack and cranking down some of its defaults as low as possible, we would need just 132M memory and 164M disk space, but we decided to have a larger safety margin