### PR TITLE
Add Exceptions Type and Message

### DIFF
--- a/cf-java-logging-support-core/beats/app-logs/docs/fields.asciidoc
+++ b/cf-java-logging-support-core/beats/app-logs/docs/fields.asciidoc
@@ -448,6 +448,28 @@ required: True
 The original log message that has been written by the application.
 
 
+==== exception_type
+
+type: string
+
+example: java.lang.NullPointerException
+
+required: False
+
+The Java class name of the logged exception when available.
+
+
+==== exception_message
+
+type: string
+
+example: Something went wrong
+
+required: False
+
+The message of the logged exception when available.
+
+
 ==== stacktrace
 
 type: array

--- a/cf-java-logging-support-core/beats/app-logs/etc/app-logs.template.json
+++ b/cf-java-logging-support-core/beats/app-logs/etc/app-logs.template.json
@@ -63,6 +63,16 @@
           "index": "not_analyzed",
           "type": "string"
         },
+        "exception_message": {
+          "doc_values": true,
+          "index": "not_analyzed",
+          "type": "string"
+        },
+        "exception_type": {
+          "doc_values": true,
+          "index": "not_analyzed",
+          "type": "string"
+        },
         "layer": {
           "doc_values": true,
           "index": "not_analyzed",

--- a/cf-java-logging-support-core/beats/app-logs/etc/fields.yml
+++ b/cf-java-logging-support-core/beats/app-logs/etc/fields.yml
@@ -312,6 +312,20 @@ app-logs:
       description: |
         The original log message that has been written by the application.
 
+    - name: "exception_type"
+      type: string
+      required: false
+      example: "java.lang.NullPointerException"
+      description: |
+        The Java class name of the logged exception when available.
+
+    - name: "exception_message"
+      type: string
+      required: false
+      example: "Something went wrong"
+      description: |
+        The message of the logged exception when available.
+
     - name: "stacktrace"
       type: array
       required: false

--- a/cf-java-logging-support-core/beats/scripts/generate_fields_docs.py
+++ b/cf-java-logging-support-core/beats/scripts/generate_fields_docs.py
@@ -71,7 +71,7 @@ grouped in the following categories:
 """.format(**dict))
 
 
-    docs = yaml.load(input)
+    docs = yaml.load(input, Loader=yaml.Loader)
 
     # fields file is empty
     if docs is None:

--- a/cf-java-logging-support-core/beats/scripts/generate_template.py
+++ b/cf-java-logging-support-core/beats/scripts/generate_template.py
@@ -22,7 +22,7 @@ def fields_to_es_template(input, output, index):
     """
 
     # Custom properties
-    docs = yaml.load(input)
+    docs = yaml.load(input, Loader=yaml.Loader)
 
     # No fields defined, can't generate template
     if docs is None:

--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/Fields.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/Fields.java
@@ -44,6 +44,8 @@ public interface Fields {
   public String THREAD = "thread";
   public String LEVEL = "level";
   public String MSG = "msg";
+  public String EXCEPTION_TYPE = "exception_type";
+  public String EXCEPTION_MESSAGE = "exception_message";
   public String STACKTRACE = "stacktrace";
   public String CATEGORIES = "categories";
   public String CUSTOM_FIELDS = "#cf";

--- a/cf-java-logging-support-log4j2/src/main/java/com/sap/hcp/cf/log4j2/layout/supppliers/BaseFieldSupplier.java
+++ b/cf-java-logging-support-log4j2/src/main/java/com/sap/hcp/cf/log4j2/layout/supppliers/BaseFieldSupplier.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.core.LogEvent;
 
 import com.sap.hcp.cf.log4j2.converter.api.Log4jContextFieldSupplier;
@@ -23,6 +24,13 @@ public class BaseFieldSupplier implements Log4jContextFieldSupplier {
         fields.put(Fields.THREAD, event.getThreadName());
         if (!LogEventUtilities.isRequestLog(event) && event.getMessage() != null) {
             fields.put(Fields.MSG, LogEventUtilities.getFormattedMessage(event));
+        }
+        if (event.getThrown() != null) {
+            Throwable throwable = event.getThrown();
+            fields.put(Fields.EXCEPTION_TYPE, throwable.getClass().getName());
+            if (StringUtils.isNotBlank(throwable.getMessage())) {
+                fields.put(Fields.EXCEPTION_MESSAGE, throwable.getMessage());
+            }
         }
         return fields;
     }

--- a/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/log4j2/layout/suppliers/BaseFieldSupplierTest.java
+++ b/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/log4j2/layout/suppliers/BaseFieldSupplierTest.java
@@ -1,0 +1,58 @@
+package com.sap.hcp.cf.log4j2.layout.suppliers;
+
+import com.sap.hcp.cf.log4j2.converter.api.Log4jContextFieldSupplier;
+import com.sap.hcp.cf.log4j2.layout.supppliers.BaseFieldSupplier;
+import com.sap.hcp.cf.logging.common.Fields;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.time.Instant;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.time.Clock;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
+
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BaseFieldSupplierTest {
+
+    @Mock
+    private LogEvent event;
+
+    private Log4jContextFieldSupplier baseFieldSupplier = new BaseFieldSupplier();
+
+    @Before
+    public void initializeEvent() {
+        when(event.getInstant()).thenReturn(mock(Instant.class));
+    }
+
+    @Test
+    public void addsNoExceptionFieldsWithoutException() {
+        Map<String, Object> fields = baseFieldSupplier.map(event);
+
+        assertThat(fields, not(hasKey(Fields.EXCEPTION_TYPE)));
+        assertThat(fields, not(hasKey(Fields.EXCEPTION_MESSAGE)));
+    }
+
+    @Test
+    public void mapsException() {
+        Exception exception = new RuntimeException("exception message");
+        when(event.getThrown()).thenReturn(exception);
+
+        Map<String, Object> fields = baseFieldSupplier.map(event);
+
+        assertThat(fields, hasEntry(Fields.EXCEPTION_TYPE, RuntimeException.class.getName()));
+        assertThat(fields, hasEntry(Fields.EXCEPTION_MESSAGE, "exception message"));
+    }
+}

--- a/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/encoder/BaseFieldSupplier.java
+++ b/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/encoder/BaseFieldSupplier.java
@@ -4,12 +4,14 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
+import ch.qos.logback.classic.spi.ThrowableProxy;
 import com.sap.hcp.cf.logback.converter.api.LogbackContextFieldSupplier;
 import com.sap.hcp.cf.logging.common.Defaults;
 import com.sap.hcp.cf.logging.common.Fields;
 import com.sap.hcp.cf.logging.common.Markers;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
+import org.apache.commons.lang3.StringUtils;
 
 public class BaseFieldSupplier implements LogbackContextFieldSupplier {
 
@@ -24,6 +26,13 @@ public class BaseFieldSupplier implements LogbackContextFieldSupplier {
         fields.put(Fields.THREAD, event.getThreadName());
         if (!isRequestLog(event)) {
             fields.put(Fields.MSG, event.getFormattedMessage());
+        }
+        if (event.getThrowableProxy() != null && event.getThrowableProxy() instanceof ThrowableProxy) {
+            Throwable throwable = ((ThrowableProxy) event.getThrowableProxy()).getThrowable();
+            fields.put(Fields.EXCEPTION_TYPE, throwable.getClass().getName());
+            if (StringUtils.isNotBlank(throwable.getMessage())) {
+                fields.put(Fields.EXCEPTION_MESSAGE, throwable.getMessage());
+            }
         }
         return fields;
     }

--- a/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logback/encoder/BaseFieldSupplierTest.java
+++ b/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logback/encoder/BaseFieldSupplierTest.java
@@ -1,0 +1,49 @@
+package com.sap.hcp.cf.logback.encoder;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.ThrowableProxy;
+import com.sap.hcp.cf.logback.converter.api.LogbackContextFieldSupplier;
+import com.sap.hcp.cf.logging.common.Fields;
+import org.apache.commons.math3.stat.inference.GTest;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BaseFieldSupplierTest {
+
+    @Mock
+    private ILoggingEvent event;
+
+    private LogbackContextFieldSupplier baseFieldSupplier = new BaseFieldSupplier();
+
+    @Test
+    public void addsNoExceptionFieldsWithoutException() {
+        Map<String, Object> fields = baseFieldSupplier.map(event);
+
+        assertThat(fields, not(hasKey(Fields.EXCEPTION_TYPE)));
+        assertThat(fields, not(hasKey(Fields.EXCEPTION_MESSAGE)));
+    }
+
+    @Test
+    public void mapsException() {
+        Exception exception = new RuntimeException("exception message");
+        when(event.getThrowableProxy()).thenReturn(new ThrowableProxy(exception));
+
+        Map<String, Object> fields = baseFieldSupplier.map(event);
+
+        assertThat(fields, hasEntry(Fields.EXCEPTION_TYPE, RuntimeException.class.getName()));
+        assertThat(fields, hasEntry(Fields.EXCEPTION_MESSAGE, "exception message"));
+    }
+}


### PR DESCRIPTION
#160 outlines the requirement to have exception type and messages in the emitted log events. This capability has been added to the BaseFieldSuppliers for the Log4j and Logback integrations. This allows users to overwrite the default values by custom ContextFieldSuppliers. The stacktrace remains to be added at the very end of the log event generation.