### PR TITLE
Upgrade logback to 1.2.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jackson-jr.version>2.14.2</jackson-jr.version>
         <slf4j.version>1.7.36</slf4j.version>
-        <logback.version>1.2.11</logback.version>
+        <logback.version>1.2.13</logback.version>
         <log4j2.version>2.20.0</log4j2.version>
         <buildnumber.plugin.version>1.4</buildnumber.plugin.version>
         <source.plugin.version>3.2.1</source.plugin.version>


### PR DESCRIPTION
This upgrade fixes CVE-2023-6481:
https://logback.qos.ch/news.html#1.2.13