### PR TITLE
Fix typo in fields documentation

### DIFF
--- a/cf-java-logging-support-core/beats/app-logs/docs/fields.asciidoc
+++ b/cf-java-logging-support-core/beats/app-logs/docs/fields.asciidoc
@@ -498,8 +498,8 @@ type: object
 
 example: "#cf": {
   "string": [
-    {"l":"some_label", "v":"some_value", "i": 0},
-    {"l":"other_label", "v":"other_value", "i": 1}
+    {"k":"some_key", "v":"some_value", "i": 0},
+    {"k":"other_key", "v":"other_value", "i": 1}
   ]
 }
 
@@ -507,7 +507,7 @@ example: "#cf": {
 required: False
 
 An object containing collections of non-standard fields.
-The field "string" contains custom fields with label "l", value "v" and an index "i".
+The field "string" contains custom fields with key "k", value "v" and an index "i".
 The index can be used for field order during parsing.
 
 NOTE: As this is "custom" there are no predefined fields here!

--- a/cf-java-logging-support-core/beats/app-logs/etc/fields.yml
+++ b/cf-java-logging-support-core/beats/app-logs/etc/fields.yml
@@ -348,13 +348,13 @@ app-logs:
       example: |
         "#cf": {
           "string": [
-            {"l":"some_label", "v":"some_value", "i": 0},
-            {"l":"other_label", "v":"other_value", "i": 1}
+            {"k":"some_key", "v":"some_value", "i": 0},
+            {"k":"other_key", "v":"other_value", "i": 1}
           ]
         }
       description: |
         An object containing collections of non-standard fields.
-        The field "string" contains custom fields with label "l", value "v" and an index "i".
+        The field "string" contains custom fields with key "k", value "v" and an index "i".
         The index can be used for field order during parsing.
 
         NOTE: As this is "custom" there are no predefined fields here!


### PR DESCRIPTION
`k` is actually used instead of `l`. Not sure if this has changed at some point or if the documentation was never correct.