### PR TITLE
DynLogEnvironment - Also wrap configuration with a LazyInitializer.

### DIFF
--- a/cf-java-logging-support-servlet/src/main/java/com/sap/hcp/cf/logging/servlet/filter/DynamicLogLevelFilter.java
+++ b/cf-java-logging-support-servlet/src/main/java/com/sap/hcp/cf/logging/servlet/filter/DynamicLogLevelFilter.java
@@ -56,7 +56,13 @@ public class DynamicLogLevelFilter extends AbstractLoggingFilter {
      *            use a lambda: {@code () -> config}
      */
     public DynamicLogLevelFilter(ConcurrentInitializer<DynamicLogLevelConfiguration> configuration) {
-        this.configuration = configuration;
+        this.configuration = new LazyInitializer<DynamicLogLevelConfiguration>() {
+
+            @Override
+            protected DynamicLogLevelConfiguration initialize() throws ConcurrentException {
+                return configuration.get();
+            }
+        };
         this.processor = new LazyInitializer<DynamicLogLevelProcessor>() {
 
             @Override


### PR DESCRIPTION
### DynLogEnvironment - Also wrap configuration with a LazyInitializer.

In the default flow, the wrapping would not be necessary. But since the `DynamicLogLevelConfiguration` is also exposed via `protected Optional<DynamicLogLevelConfiguration> getConfiguration()`, it is recreated on each invocation.
(Another solution would be to remove getConfiguration(), but this is breaking API contracts)
