### PR TITLE
Align correlationID filter with LogContext::getCorrelationId()

### DIFF
--- a/cf-java-logging-support-servlet/src/main/java/com/sap/hcp/cf/logging/servlet/filter/CorrelationIdFilter.java
+++ b/cf-java-logging-support-servlet/src/main/java/com/sap/hcp/cf/logging/servlet/filter/CorrelationIdFilter.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.sap.hcp.cf.logging.common.Fields;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,7 +45,7 @@ public class CorrelationIdFilter extends AbstractLoggingFilter {
     @Override
     protected void beforeFilter(HttpServletRequest request, HttpServletResponse response) {
         String correlationId = determineCorrelationId(request);
-        LogContext.add(correlationHeader.getField(), correlationId);
+        LogContext.add(Fields.CORRELATION_ID, correlationId);
         addCorrelationIdHeader(response, correlationId);
     }
 
@@ -93,6 +94,6 @@ public class CorrelationIdFilter extends AbstractLoggingFilter {
 
     @Override
     protected void cleanup(HttpServletRequest request, HttpServletResponse response) {
-        LogContext.remove(correlationHeader.getField());
+        LogContext.remove(Fields.CORRELATION_ID);
     }
 }


### PR DESCRIPTION
### Align correlationID filter with LogContext::getCorrelationId()

This PR is a bit tricky about correctness. From a CorrelationIdFilter, the FieldName can be defined and it behaves locally correct. However, LogContext::getCorrelationId() mandates the field Fields.CORRELATION_ID for the correlationId.

It can be seen differently - I prepared a PR instead of an Issue since I personally tend to change it.
I classify the change as a low risk that only applies in case a custom correlation id header field is used.