### PR TITLE
Add support for HTTP header x-correlation-id

### DIFF
--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/request/HttpHeaders.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/request/HttpHeaders.java
@@ -1,64 +1,58 @@
 package com.sap.hcp.cf.logging.common.request;
 
-import static java.util.Arrays.asList;
-import static java.util.Collections.unmodifiableList;
+import com.sap.hcp.cf.logging.common.Defaults;
+import com.sap.hcp.cf.logging.common.Fields;
+import com.sap.hcp.cf.logging.common.LogContext;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import com.sap.hcp.cf.logging.common.Defaults;
-import com.sap.hcp.cf.logging.common.Fields;
-import com.sap.hcp.cf.logging.common.LogContext;
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
 
 public enum HttpHeaders implements HttpHeader {
-                                               CONTENT_LENGTH("content-length"), //
-                                               CONTENT_TYPE("content-type"), //
-                                               REFERER("referer"), //
-                                               X_CUSTOM_HOST("x-custom-host", Fields.X_CUSTOM_HOST), //
-                                               X_FORWARDED_FOR("x-forwarded-for", Fields.X_FORWARDED_FOR), //
-                                               X_FORWARDED_HOST("x-forwarded-host", Fields.X_FORWARDED_HOST), //
-                                               X_FORWARDED_PROTO("x-forwarded-proto", Fields.X_FORWARDED_PROTO), //
-                                               X_SSL_CLIENT("x-ssl-client", Fields.X_SSL_CLIENT), //
-                                               X_SSL_CLIENT_VERIFY("x-ssl-client-verify", Fields.X_SSL_CLIENT_VERIFY), //
-                                               X_SSL_CLIENT_SUBJECT_DN("x-ssl-client-subject-dn",
-                                                                       Fields.X_SSL_CLIENT_SUBJECT_DN), //
-                                               X_SSL_CLIENT_SUBJECT_CN("x-ssl-client-subject-cn",
-                                                                       Fields.X_SSL_CLIENT_SUBJECT_CN), //
-                                               X_SSL_CLIENT_ISSUER_DN("x-ssl-client-issuer-dn",
-                                                                      Fields.X_SSL_CLIENT_ISSUER_DN), //
-                                               X_SSL_CLIENT_NOTBEFORE("x-ssl-client-notbefore",
-                                                                      Fields.X_SSL_CLIENT_NOTBEFORE), //
-                                               X_SSL_CLIENT_NOTAFTER("x-ssl-client-notafter",
-                                                                     Fields.X_SSL_CLIENT_NOTAFTER), //
-                                               X_SSL_CLIENT_SESSION_ID("x-ssl-client-session-id",
-                                                                       Fields.X_SSL_CLIENT_SESSION_ID), //
-                                               X_VCAP_REQUEST_ID("x-vcap-request-id", Fields.REQUEST_ID, true), //
-                                               CORRELATION_ID("X-CorrelationID", Fields.CORRELATION_ID, true,
-                                                              X_VCAP_REQUEST_ID), //
-                                               W3C_TRACEPARENT("traceparent", Fields.W3C_TRACEPARENT, true),
-                                               SAP_PASSPORT("sap-passport", Fields.SAP_PASSPORT, true), //
-                                               TENANT_ID("tenantid", Fields.TENANT_ID, true); //
+    CONTENT_LENGTH("content-length"), //
+    CONTENT_TYPE("content-type"), //
+    REFERER("referer"), //
+    X_CUSTOM_HOST("x-custom-host", Fields.X_CUSTOM_HOST), //
+    X_FORWARDED_FOR("x-forwarded-for", Fields.X_FORWARDED_FOR), //
+    X_FORWARDED_HOST("x-forwarded-host", Fields.X_FORWARDED_HOST), //
+    X_FORWARDED_PROTO("x-forwarded-proto", Fields.X_FORWARDED_PROTO), //
+    X_SSL_CLIENT("x-ssl-client", Fields.X_SSL_CLIENT), //
+    X_SSL_CLIENT_VERIFY("x-ssl-client-verify", Fields.X_SSL_CLIENT_VERIFY), //
+    X_SSL_CLIENT_SUBJECT_DN("x-ssl-client-subject-dn", Fields.X_SSL_CLIENT_SUBJECT_DN), //
+    X_SSL_CLIENT_SUBJECT_CN("x-ssl-client-subject-cn", Fields.X_SSL_CLIENT_SUBJECT_CN), //
+    X_SSL_CLIENT_ISSUER_DN("x-ssl-client-issuer-dn", Fields.X_SSL_CLIENT_ISSUER_DN), //
+    X_SSL_CLIENT_NOTBEFORE("x-ssl-client-notbefore", Fields.X_SSL_CLIENT_NOTBEFORE), //
+    X_SSL_CLIENT_NOTAFTER("x-ssl-client-notafter", Fields.X_SSL_CLIENT_NOTAFTER), //
+    X_SSL_CLIENT_SESSION_ID("x-ssl-client-session-id", Fields.X_SSL_CLIENT_SESSION_ID), //
+    X_VCAP_REQUEST_ID("x-vcap-request-id", Fields.REQUEST_ID, true), //
+    X_CORRELATION_ID_ALTERNATIVE("x-correlation-id"), //
+    CORRELATION_ID("X-CorrelationID", Fields.CORRELATION_ID, true, X_CORRELATION_ID_ALTERNATIVE, X_VCAP_REQUEST_ID), //
+    W3C_TRACEPARENT("traceparent", Fields.W3C_TRACEPARENT, true),
+    SAP_PASSPORT("sap-passport", Fields.SAP_PASSPORT, true), //
+    TENANT_ID("tenantid", Fields.TENANT_ID, true); //
 
-    private HttpHeaders(String name) {
+    HttpHeaders(String name) {
         this(name, null);
     }
 
-    private HttpHeaders(String name, String field) {
+    HttpHeaders(String name, String field) {
         this(name, field, false);
     }
 
-    private HttpHeaders(String name, String field, boolean isPropagated, HttpHeaders... aliases) {
+    HttpHeaders(String name, String field, boolean isPropagated, HttpHeaders... aliases) {
         this.name = name;
         this.field = field;
         this.isPropagated = isPropagated;
         this.aliases = unmodifiableList(asList(aliases));
     }
 
-    private String name;
-    private String field;
-    private boolean isPropagated;
-    private List<HttpHeader> aliases;
+    private final String name;
+    private final String field;
+    private final boolean isPropagated;
+    private final List<HttpHeader> aliases;
 
     @Override
     public boolean isPropagated() {

--- a/cf-java-logging-support-core/src/test/java/com/sap/hcp/cf/logging/common/request/HttpHeadersTest.java
+++ b/cf-java-logging-support-core/src/test/java/com/sap/hcp/cf/logging/common/request/HttpHeadersTest.java
@@ -1,18 +1,13 @@
 package com.sap.hcp.cf.logging.common.request;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
-
-import org.junit.Before;
-import org.junit.Test;
-
 import com.sap.hcp.cf.logging.common.Defaults;
 import com.sap.hcp.cf.logging.common.Fields;
 import com.sap.hcp.cf.logging.common.LogContext;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 
 public class HttpHeadersTest {
 
@@ -24,7 +19,7 @@ public class HttpHeadersTest {
 
     @Test
     public void hasCorrectNumberOfTypes() throws Exception {
-        assertThat(HttpHeaders.values().length, is(equalTo(20)));
+        assertThat(HttpHeaders.values().length, is(equalTo(21)));
     }
 
     @Test
@@ -32,6 +27,7 @@ public class HttpHeadersTest {
         assertThat(HttpHeaders.CONTENT_LENGTH.getName(), is("content-length"));
         assertThat(HttpHeaders.CONTENT_TYPE.getName(), is("content-type"));
         assertThat(HttpHeaders.CORRELATION_ID.getName(), is("X-CorrelationID"));
+        assertThat(HttpHeaders.X_CORRELATION_ID_ALTERNATIVE.getName(), is("x-correlation-id"));
         assertThat(HttpHeaders.REFERER.getName(), is("referer"));
         assertThat(HttpHeaders.TENANT_ID.getName(), is("tenantid"));
         assertThat(HttpHeaders.W3C_TRACEPARENT.getName(), is("traceparent"));
@@ -55,6 +51,7 @@ public class HttpHeadersTest {
         assertThat(HttpHeaders.CONTENT_LENGTH.getField(), is(nullValue()));
         assertThat(HttpHeaders.CONTENT_TYPE.getField(), is(nullValue()));
         assertThat(HttpHeaders.CORRELATION_ID.getField(), is(Fields.CORRELATION_ID));
+        assertThat(HttpHeaders.X_CORRELATION_ID_ALTERNATIVE.getField(), is(nullValue()));
         assertThat(HttpHeaders.REFERER.getField(), is(nullValue()));
         assertThat(HttpHeaders.TENANT_ID.getField(), is(Fields.TENANT_ID));
         assertThat(HttpHeaders.W3C_TRACEPARENT.getField(), is(Fields.W3C_TRACEPARENT));
@@ -83,8 +80,9 @@ public class HttpHeadersTest {
     @Test
     public void defaultFieldValueIsNullForProgatedHeaders() throws Exception {
         for (HttpHeader header: HttpHeaders.propagated()) {
-            assertThat("Default of field <" + header.getField() + "> from header <" + header.getName() +
-                       "> should be null", header.getFieldValue(), is(nullValue()));
+            assertThat(
+                    "Default of field <" + header.getField() + "> from header <" + header.getName() + "> should be null",
+                    header.getFieldValue(), is(nullValue()));
         }
     }
 
@@ -92,7 +90,8 @@ public class HttpHeadersTest {
     public void hasCorrectAliases() throws Exception {
         assertThat(HttpHeaders.CONTENT_LENGTH.getAliases(), is(empty()));
         assertThat(HttpHeaders.CONTENT_TYPE.getAliases(), is(empty()));
-        assertThat(HttpHeaders.CORRELATION_ID.getAliases(), containsInAnyOrder(HttpHeaders.X_VCAP_REQUEST_ID));
+        assertThat(HttpHeaders.CORRELATION_ID.getAliases(),
+                   containsInAnyOrder(HttpHeaders.X_CORRELATION_ID_ALTERNATIVE, HttpHeaders.X_VCAP_REQUEST_ID));
         assertThat(HttpHeaders.REFERER.getAliases(), is(empty()));
         assertThat(HttpHeaders.TENANT_ID.getAliases(), is(empty()));
         assertThat(HttpHeaders.W3C_TRACEPARENT.getAliases(), is(empty()));
@@ -113,9 +112,9 @@ public class HttpHeadersTest {
 
     @Test
     public void propagatesCorrectHeaders() throws Exception {
-        assertThat(HttpHeaders.propagated(), containsInAnyOrder(HttpHeaders.CORRELATION_ID, HttpHeaders.SAP_PASSPORT,
-                                                                HttpHeaders.TENANT_ID, HttpHeaders.W3C_TRACEPARENT,
-                                                                HttpHeaders.X_VCAP_REQUEST_ID));
+        assertThat(HttpHeaders.propagated(),
+                   containsInAnyOrder(HttpHeaders.CORRELATION_ID, HttpHeaders.SAP_PASSPORT, HttpHeaders.TENANT_ID,
+                                      HttpHeaders.W3C_TRACEPARENT, HttpHeaders.X_VCAP_REQUEST_ID));
     }
 
 }


### PR DESCRIPTION
The request instrumentation creates a correlation id. This used to look into the HTTP headers `x-CorrelationID` and `x-vcap-request-id`. This new implementation additionally looks into `x-correlation-id` with priority between the two other headers.

The downside of this change is, that it might not be aligned with the Gorouter logs. The Gorouter might log either HTTP header `x-CorrelationID` and/or `x-correlation-id`. But it will always create an `x-vcap-request-id` which is seen by the application. This might create deviations in log parsing for correlation ids, when the newly supported header is used.