### PR TITLE
Support SPI Loading of ContextFieldSuppliers for Logback

### DIFF
--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/serialization/ContextFieldSupplier.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/serialization/ContextFieldSupplier.java
@@ -4,5 +4,14 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 @FunctionalInterface
-public interface ContextFieldSupplier extends Supplier<Map<String, Object>> {
+public interface ContextFieldSupplier extends Supplier<Map<String, Object>>, Comparable<ContextFieldSupplier> {
+
+    default int order() {
+        return 0;
+    }
+
+    @Override
+    default int compareTo(ContextFieldSupplier other) {
+        return order() - other.order();
+    }
 }

--- a/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/converter/api/LogbackContextFieldSupplier.java
+++ b/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/converter/api/LogbackContextFieldSupplier.java
@@ -6,4 +6,7 @@ import com.sap.hcp.cf.logging.common.serialization.EventContextFieldSupplier;
 @FunctionalInterface
 public interface LogbackContextFieldSupplier extends EventContextFieldSupplier<ILoggingEvent> {
 
+    int BASE_FIELDS = -100;
+    int CONTEXT_FIELDS = -90;
+    int REQUEST_FIELDS = -80;
 }

--- a/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/encoder/BaseFieldSupplier.java
+++ b/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/encoder/BaseFieldSupplier.java
@@ -15,6 +15,11 @@ import java.util.Map;
 public class BaseFieldSupplier implements LogbackContextFieldSupplier {
 
     @Override
+    public int order() {
+        return LogbackContextFieldSupplier.BASE_FIELDS;
+    }
+
+    @Override
     public Map<String, Object> map(ILoggingEvent event) {
         Map<String, Object> fields = new HashMap<>(6);
         fields.put(Fields.WRITTEN_AT, Instant.ofEpochMilli(event.getTimeStamp()).toString());

--- a/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/encoder/ContextFieldSuppliersServiceLoader.java
+++ b/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/encoder/ContextFieldSuppliersServiceLoader.java
@@ -1,0 +1,31 @@
+package com.sap.hcp.cf.logback.encoder;
+
+import com.sap.hcp.cf.logback.converter.api.LogbackContextFieldSupplier;
+import com.sap.hcp.cf.logging.common.serialization.ContextFieldSupplier;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class ContextFieldSuppliersServiceLoader {
+
+    private ContextFieldSuppliersServiceLoader() {
+    }
+
+    public static ArrayList<ContextFieldSupplier> addSpiContextFieldSuppliers(
+            List<ContextFieldSupplier> fieldSuppliers) {
+        return addFieldSupplier(fieldSuppliers, ContextFieldSupplier.class);
+    }
+
+    private static <T extends ContextFieldSupplier> ArrayList<T> addFieldSupplier(List<T> original, Class<T> clazz) {
+        Stream<T> spiSuppliers = ServiceLoader.load(clazz).stream().map(ServiceLoader.Provider::get).sorted();
+        return Stream.concat(original.stream(), spiSuppliers).sorted().collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    public static ArrayList<LogbackContextFieldSupplier> addSpiLogbackContextFieldSuppliers(
+            List<LogbackContextFieldSupplier> original) {
+        return addFieldSupplier(original, LogbackContextFieldSupplier.class);
+    }
+}

--- a/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/encoder/EventContextFieldSupplier.java
+++ b/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/encoder/EventContextFieldSupplier.java
@@ -10,6 +10,11 @@ public class EventContextFieldSupplier extends AbstractContextFieldSupplier<ILog
         implements LogbackContextFieldSupplier {
 
     @Override
+    public int order() {
+        return LogbackContextFieldSupplier.CONTEXT_FIELDS;
+    }
+
+    @Override
     protected Object[] getParameterArray(ILoggingEvent event) {
         return event.getArgumentArray();
     }

--- a/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/encoder/RequestRecordFieldSupplier.java
+++ b/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/encoder/RequestRecordFieldSupplier.java
@@ -8,6 +8,11 @@ public class RequestRecordFieldSupplier extends AbstractRequestRecordFieldSuppli
         implements LogbackContextFieldSupplier {
 
     @Override
+    public int order() {
+        return LogbackContextFieldSupplier.REQUEST_FIELDS;
+    }
+
+    @Override
     protected boolean isRequestLog(ILoggingEvent event) {
         return ILoggingEventUtilities.isRequestLog(event);
     }

--- a/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logback/encoder/ContextFieldSuppliersServiceLoaderTest.java
+++ b/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logback/encoder/ContextFieldSuppliersServiceLoaderTest.java
@@ -1,0 +1,130 @@
+package com.sap.hcp.cf.logback.encoder;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import com.sap.hcp.cf.logback.converter.api.LogbackContextFieldSupplier;
+import com.sap.hcp.cf.logging.common.serialization.ContextFieldSupplier;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static com.sap.hcp.cf.logback.encoder.ContextFieldSuppliersServiceLoader.addSpiContextFieldSuppliers;
+import static com.sap.hcp.cf.logback.encoder.ContextFieldSuppliersServiceLoader.addSpiLogbackContextFieldSuppliers;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ContextFieldSuppliersServiceLoaderTest {
+
+    @Test
+    void loadsSpiContextFieldSuppliers() {
+        List<ContextFieldSupplier> fieldSuppliers = addSpiContextFieldSuppliers(emptyList());
+        assertThat(fieldSuppliers).map(s -> s.getClass().getName())
+                                  .containsExactly(FirstContextFieldSupplier.class.getName(),
+                                                   SecondContextFieldSupplier.class.getName());
+    }
+
+    @Test
+    void stableSortsContextFieldSuppliers() {
+        List<ContextFieldSupplier> fieldSuppliers =
+                addSpiContextFieldSuppliers(List.of(new NoopContextFieldSupplier(2)));
+        assertThat(fieldSuppliers).map(s -> s.getClass().getName())
+                                  .containsExactly(FirstContextFieldSupplier.class.getName(),
+                                                   NoopContextFieldSupplier.class.getName(),
+                                                   SecondContextFieldSupplier.class.getName());
+    }
+
+    @Test
+    void loadsSpiLogbackContextFieldSuppliers() {
+        List<LogbackContextFieldSupplier> fieldSuppliers = addSpiLogbackContextFieldSuppliers(emptyList());
+        assertThat(fieldSuppliers).map(s -> s.getClass().getName())
+                                  .containsExactly(FirstLogbackContextFieldSupplier.class.getName(),
+                                                   SecondLogbackContextFieldSupplier.class.getName());
+    }
+
+    @Test
+    void stableSortsLogbackContextFieldSuppliers() {
+        List<LogbackContextFieldSupplier> fieldSuppliers =
+                addSpiLogbackContextFieldSuppliers(List.of(new NoopLogbackContextFieldSupplier(2)));
+        assertThat(fieldSuppliers).map(s -> s.getClass().getName())
+                                  .containsExactly(FirstLogbackContextFieldSupplier.class.getName(),
+                                                   NoopLogbackContextFieldSupplier.class.getName(),
+                                                   SecondLogbackContextFieldSupplier.class.getName());
+    }
+
+    @Test
+    void retainsLegacyOrdering() {
+        List<LogbackContextFieldSupplier> fieldSuppliers = addSpiLogbackContextFieldSuppliers(
+                List.of(new RequestRecordFieldSupplier(), new BaseFieldSupplier(),
+                        new NoopLogbackContextFieldSupplier(0), new EventContextFieldSupplier()));
+        assertThat(fieldSuppliers).map(s -> s.getClass().getName()).containsExactly(BaseFieldSupplier.class.getName(),
+                                                                                    EventContextFieldSupplier.class.getName(),
+                                                                                    RequestRecordFieldSupplier.class.getName(),
+                                                                                    NoopLogbackContextFieldSupplier.class.getName(),
+                                                                                    FirstLogbackContextFieldSupplier.class.getName(),
+                                                                                    SecondLogbackContextFieldSupplier.class.getName());
+
+    }
+
+    private static class NoopContextFieldSupplier implements ContextFieldSupplier {
+
+        private final int order;
+
+        private NoopContextFieldSupplier(int order) {
+            this.order = order;
+        }
+
+        @Override
+        public Map<String, Object> get() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public int order() {
+            return order;
+        }
+    }
+
+    public static class FirstContextFieldSupplier extends NoopContextFieldSupplier {
+        public FirstContextFieldSupplier() {
+            super(1);
+        }
+    }
+
+    public static class SecondContextFieldSupplier extends NoopContextFieldSupplier {
+        public SecondContextFieldSupplier() {
+            super(2);
+        }
+    }
+
+    private static class NoopLogbackContextFieldSupplier implements LogbackContextFieldSupplier {
+
+        private final int order;
+
+        private NoopLogbackContextFieldSupplier(int order) {
+            this.order = order;
+        }
+
+        @Override
+        public int order() {
+            return order;
+        }
+
+        @Override
+        public Map<String, Object> map(ILoggingEvent event) {
+            return Collections.emptyMap();
+        }
+    }
+
+    public static class FirstLogbackContextFieldSupplier extends NoopLogbackContextFieldSupplier {
+        public FirstLogbackContextFieldSupplier() {
+            super(1);
+        }
+    }
+
+    public static class SecondLogbackContextFieldSupplier extends NoopLogbackContextFieldSupplier {
+        public SecondLogbackContextFieldSupplier() {
+            super(2);
+        }
+    }
+}

--- a/cf-java-logging-support-logback/src/test/resources/META-INF/services/com.sap.hcp.cf.logback.converter.api.LogbackContextFieldSupplier
+++ b/cf-java-logging-support-logback/src/test/resources/META-INF/services/com.sap.hcp.cf.logback.converter.api.LogbackContextFieldSupplier
@@ -1,0 +1,2 @@
+com.sap.hcp.cf.logback.encoder.ContextFieldSuppliersServiceLoaderTest$FirstLogbackContextFieldSupplier
+com.sap.hcp.cf.logback.encoder.ContextFieldSuppliersServiceLoaderTest$SecondLogbackContextFieldSupplier

--- a/cf-java-logging-support-logback/src/test/resources/META-INF/services/com.sap.hcp.cf.logging.common.serialization.ContextFieldSupplier
+++ b/cf-java-logging-support-logback/src/test/resources/META-INF/services/com.sap.hcp.cf.logging.common.serialization.ContextFieldSupplier
@@ -1,0 +1,2 @@
+com.sap.hcp.cf.logback.encoder.ContextFieldSuppliersServiceLoaderTest$FirstContextFieldSupplier
+com.sap.hcp.cf.logback.encoder.ContextFieldSuppliersServiceLoaderTest$SecondContextFieldSupplier


### PR DESCRIPTION
This allows declaration of ContextFieldSuppliers and LogbackContextFieldSuppliers via SPI. The newly introduced order is respected when the suppliers are executed. The old mechanism with XML configuration is retained.