### PR TITLE
Support SLF4J Key-Value-Pairs

### DIFF
--- a/cf-java-logging-support-log4j2/src/main/java/com/sap/hcp/cf/log4j2/layout/JsonPatternLayout.java
+++ b/cf-java-logging-support-log4j2/src/main/java/com/sap/hcp/cf/log4j2/layout/JsonPatternLayout.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.jr.ob.comp.ArrayComposer;
 import com.fasterxml.jackson.jr.ob.comp.ComposerBase;
 import com.fasterxml.jackson.jr.ob.comp.ObjectComposer;
 import com.sap.hcp.cf.log4j2.converter.api.Log4jContextFieldSupplier;
-import com.sap.hcp.cf.log4j2.layout.supppliers.LogEventUtilities;
+import com.sap.hcp.cf.log4j2.layout.suppliers.LogEventUtilities;
 import com.sap.hcp.cf.logging.common.Fields;
 import com.sap.hcp.cf.logging.common.converter.LineWriter;
 import com.sap.hcp.cf.logging.common.converter.StacktraceLines;

--- a/cf-java-logging-support-log4j2/src/main/java/com/sap/hcp/cf/log4j2/layout/suppliers/BaseFieldSupplier.java
+++ b/cf-java-logging-support-log4j2/src/main/java/com/sap/hcp/cf/log4j2/layout/suppliers/BaseFieldSupplier.java
@@ -1,4 +1,4 @@
-package com.sap.hcp.cf.log4j2.layout.supppliers;
+package com.sap.hcp.cf.log4j2.layout.suppliers;
 
 import com.sap.hcp.cf.log4j2.converter.api.Log4jContextFieldSupplier;
 import com.sap.hcp.cf.logging.common.Defaults;

--- a/cf-java-logging-support-log4j2/src/main/java/com/sap/hcp/cf/log4j2/layout/suppliers/EventContextFieldSupplier.java
+++ b/cf-java-logging-support-log4j2/src/main/java/com/sap/hcp/cf/log4j2/layout/suppliers/EventContextFieldSupplier.java
@@ -1,4 +1,4 @@
-package com.sap.hcp.cf.log4j2.layout.supppliers;
+package com.sap.hcp.cf.log4j2.layout.suppliers;
 
 import com.sap.hcp.cf.log4j2.converter.api.Log4jContextFieldSupplier;
 import com.sap.hcp.cf.logging.common.serialization.AbstractContextFieldSupplier;

--- a/cf-java-logging-support-log4j2/src/main/java/com/sap/hcp/cf/log4j2/layout/suppliers/LogEventUtilities.java
+++ b/cf-java-logging-support-log4j2/src/main/java/com/sap/hcp/cf/log4j2/layout/suppliers/LogEventUtilities.java
@@ -1,4 +1,4 @@
-package com.sap.hcp.cf.log4j2.layout.supppliers;
+package com.sap.hcp.cf.log4j2.layout.suppliers;
 
 import com.sap.hcp.cf.logging.common.Markers;
 import org.apache.logging.log4j.core.LogEvent;

--- a/cf-java-logging-support-log4j2/src/main/java/com/sap/hcp/cf/log4j2/layout/suppliers/RequestRecordFieldSupplier.java
+++ b/cf-java-logging-support-log4j2/src/main/java/com/sap/hcp/cf/log4j2/layout/suppliers/RequestRecordFieldSupplier.java
@@ -1,4 +1,4 @@
-package com.sap.hcp.cf.log4j2.layout.supppliers;
+package com.sap.hcp.cf.log4j2.layout.suppliers;
 
 import com.sap.hcp.cf.log4j2.converter.api.Log4jContextFieldSupplier;
 import com.sap.hcp.cf.logging.common.serialization.AbstractRequestRecordFieldSupplier;

--- a/cf-java-logging-support-log4j2/src/main/resources/META-INF/services/com.sap.hcp.cf.log4j2.converter.api.Log4jContextFieldSupplier
+++ b/cf-java-logging-support-log4j2/src/main/resources/META-INF/services/com.sap.hcp.cf.log4j2.converter.api.Log4jContextFieldSupplier
@@ -1,3 +1,3 @@
-com.sap.hcp.cf.log4j2.layout.supppliers.BaseFieldSupplier
-com.sap.hcp.cf.log4j2.layout.supppliers.EventContextFieldSupplier
-com.sap.hcp.cf.log4j2.layout.supppliers.RequestRecordFieldSupplier
+com.sap.hcp.cf.log4j2.layout.suppliers.BaseFieldSupplier
+com.sap.hcp.cf.log4j2.layout.suppliers.EventContextFieldSupplier
+com.sap.hcp.cf.log4j2.layout.suppliers.RequestRecordFieldSupplier

--- a/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/log4j2/layout/JsonPatternLayoutTest.java
+++ b/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/log4j2/layout/JsonPatternLayoutTest.java
@@ -1,9 +1,9 @@
 package com.sap.hcp.cf.log4j2.layout;
 
 import com.sap.hcp.cf.log4j2.converter.api.Log4jContextFieldSupplier;
-import com.sap.hcp.cf.log4j2.layout.supppliers.BaseFieldSupplier;
-import com.sap.hcp.cf.log4j2.layout.supppliers.EventContextFieldSupplier;
-import com.sap.hcp.cf.log4j2.layout.supppliers.RequestRecordFieldSupplier;
+import com.sap.hcp.cf.log4j2.layout.suppliers.BaseFieldSupplier;
+import com.sap.hcp.cf.log4j2.layout.suppliers.EventContextFieldSupplier;
+import com.sap.hcp.cf.log4j2.layout.suppliers.RequestRecordFieldSupplier;
 import com.sap.hcp.cf.logging.common.serialization.ContextFieldSupplier;
 import org.apache.logging.log4j.core.LogEvent;
 import org.junit.jupiter.api.Test;

--- a/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/log4j2/layout/suppliers/BaseFieldSupplierTest.java
+++ b/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/log4j2/layout/suppliers/BaseFieldSupplierTest.java
@@ -1,7 +1,6 @@
 package com.sap.hcp.cf.log4j2.layout.suppliers;
 
 import com.sap.hcp.cf.log4j2.converter.api.Log4jContextFieldSupplier;
-import com.sap.hcp.cf.log4j2.layout.supppliers.BaseFieldSupplier;
 import com.sap.hcp.cf.logging.common.Fields;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.time.Instant;

--- a/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/log4j2/layout/suppliers/EventContextFieldSupplierTest.java
+++ b/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/log4j2/layout/suppliers/EventContextFieldSupplierTest.java
@@ -1,7 +1,6 @@
 package com.sap.hcp.cf.log4j2.layout.suppliers;
 
 import com.sap.hcp.cf.log4j2.converter.api.Log4jContextFieldSupplier;
-import com.sap.hcp.cf.log4j2.layout.supppliers.EventContextFieldSupplier;
 import com.sap.hcp.cf.logging.common.customfields.CustomField;
 import org.apache.logging.log4j.core.LogEvent;
 import org.junit.jupiter.api.Test;

--- a/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/log4j2/layout/suppliers/RequestRecordFieldSupplierTest.java
+++ b/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/log4j2/layout/suppliers/RequestRecordFieldSupplierTest.java
@@ -1,7 +1,6 @@
 package com.sap.hcp.cf.log4j2.layout.suppliers;
 
 import com.sap.hcp.cf.log4j2.converter.api.Log4jContextFieldSupplier;
-import com.sap.hcp.cf.log4j2.layout.supppliers.RequestRecordFieldSupplier;
 import com.sap.hcp.cf.logging.common.Fields;
 import com.sap.hcp.cf.logging.common.Markers;
 import com.sap.hcp.cf.logging.common.request.RequestRecord;

--- a/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/logging/common/TestAppLog.java
+++ b/cf-java-logging-support-log4j2/src/test/java/com/sap/hcp/cf/logging/common/TestAppLog.java
@@ -151,4 +151,22 @@ public class TestAppLog {
         LOGGER.info(jsonMsg);
         assertLastEventMessage(console).isEqualTo(jsonMsg);
     }
+
+    @Test
+    void testKeyValuePairs(ConsoleOutput console) {
+        LOGGER.atInfo().addKeyValue(CUSTOM_FIELD_KEY, SOME_VALUE).addKeyValue(RETAINED_FIELD_KEY, SOME_OTHER_VALUE)
+              .addKeyValue(SOME_KEY, SOME_VALUE).log(TEST_MESSAGE);
+
+        assertLastEventMessage(console).isEqualTo(TEST_MESSAGE);
+        assertLastEventCustomFields(console) //
+                                             .anySatisfy(e -> assertCustomField(e).hasKey(CUSTOM_FIELD_KEY)
+                                                                                  .hasValue(SOME_VALUE)
+                                                                                  .hasIndex(CUSTOM_FIELD_INDEX))
+                                             .anySatisfy(e -> assertCustomField(e).hasKey(RETAINED_FIELD_KEY)
+                                                                                  .hasValue(SOME_OTHER_VALUE)
+                                                                                  .hasIndex(RETAINED_FIELD_INDEX));
+        assertLastEventFields(console).containsEntry(RETAINED_FIELD_KEY, SOME_OTHER_VALUE);
+        assertLastEventFields(console).containsEntry(SOME_KEY, SOME_VALUE);
+    }
+
 }

--- a/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/encoder/KeyValuePairsFieldSupplier.java
+++ b/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/encoder/KeyValuePairsFieldSupplier.java
@@ -1,0 +1,24 @@
+package com.sap.hcp.cf.logback.encoder;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import com.sap.hcp.cf.logback.converter.api.LogbackContextFieldSupplier;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static java.util.stream.Collectors.toMap;
+
+public class KeyValuePairsFieldSupplier implements LogbackContextFieldSupplier {
+    @Override
+    public int order() {
+        return LogbackContextFieldSupplier.CONTEXT_FIELDS + 1;
+    }
+
+    @Override
+    public Map<String, Object> map(ILoggingEvent event) {
+        if (event == null || event.getKeyValuePairs() == null) {
+            return Collections.emptyMap();
+        }
+        return event.getKeyValuePairs().stream().collect(toMap(p -> p.key, p -> p.value));
+    }
+}

--- a/cf-java-logging-support-logback/src/main/resources/META-INF/services/com.sap.hcp.cf.logback.converter.api.LogbackContextFieldSupplier
+++ b/cf-java-logging-support-logback/src/main/resources/META-INF/services/com.sap.hcp.cf.logback.converter.api.LogbackContextFieldSupplier
@@ -1,3 +1,4 @@
 com.sap.hcp.cf.logback.encoder.BaseFieldSupplier
 com.sap.hcp.cf.logback.encoder.EventContextFieldSupplier
+com.sap.hcp.cf.logback.encoder.KeyValuePairsFieldSupplier
 com.sap.hcp.cf.logback.encoder.RequestRecordFieldSupplier

--- a/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logback/encoder/JsonEncoderTest.java
+++ b/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logback/encoder/JsonEncoderTest.java
@@ -34,6 +34,7 @@ class JsonEncoderTest {
         assertThat(ENCODER.getLogbackContextFieldSuppliers()).map(Object::getClass).map(Class::getName)
                                                              .containsExactly(BaseFieldSupplier.class.getName(),
                                                                               EventContextFieldSupplier.class.getName(),
+                                                                              KeyValuePairsFieldSupplier.class.getName(),
                                                                               RequestRecordFieldSupplier.class.getName(),
                                                                               SampleLogbackContextFieldSupplier.class.getName(),
                                                                               SpiLogbackContextFieldSupplier.class.getName());

--- a/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logback/encoder/KeyValuePairsFieldSupplierTest.java
+++ b/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logback/encoder/KeyValuePairsFieldSupplierTest.java
@@ -1,0 +1,49 @@
+package com.sap.hcp.cf.logback.encoder;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.event.KeyValuePair;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class KeyValuePairsFieldSupplierTest {
+
+    private final KeyValuePairsFieldSupplier supplier = new KeyValuePairsFieldSupplier();
+
+    @Mock
+    private ILoggingEvent event;
+
+    @Test
+    void nullEvent() {
+        assertThat(supplier.map(null)).isEmpty();
+    }
+
+    @Test
+    void nullKeyValuePairs() {
+        when(event.getKeyValuePairs()).thenReturn(null);
+        assertThat(supplier.map(event)).isEmpty();
+    }
+
+    @Test
+    void emptyKeyValuePairs() {
+        when(event.getKeyValuePairs()).thenReturn(Collections.emptyList());
+        assertThat(supplier.map(event)).isEmpty();
+
+    }
+
+    @Test
+    void multipleKeyValuePairs() {
+        KeyValuePair pair1 = new KeyValuePair("key1", "value1");
+        KeyValuePair pair2 = new KeyValuePair("key2", 123);
+        when(event.getKeyValuePairs()).thenReturn(Arrays.asList(pair1, pair2));
+        assertThat(supplier.map(event)).containsEntry("key1", "value1").containsEntry("key2", 123);
+    }
+}

--- a/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logging/common/TestAppLog.java
+++ b/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logging/common/TestAppLog.java
@@ -143,4 +143,21 @@ public class TestAppLog {
         assertLastEventMessage(console).isEqualTo(jsonMsg);
     }
 
+    @Test
+    void testKeyValuePairs(ConsoleOutput console) {
+        LOGGER.atInfo().addKeyValue(CUSTOM_FIELD_KEY, SOME_VALUE).addKeyValue(RETAINED_FIELD_KEY, SOME_OTHER_VALUE)
+              .addKeyValue(SOME_KEY, SOME_VALUE).log(TEST_MESSAGE);
+
+        assertLastEventMessage(console).isEqualTo(TEST_MESSAGE);
+        assertLastEventCustomFields(console) //
+                                             .anySatisfy(e -> assertCustomField(e).hasKey(CUSTOM_FIELD_KEY)
+                                                                                  .hasValue(SOME_VALUE)
+                                                                                  .hasIndex(CUSTOM_FIELD_INDEX))
+                                             .anySatisfy(e -> assertCustomField(e).hasKey(RETAINED_FIELD_KEY)
+                                                                                  .hasValue(SOME_OTHER_VALUE)
+                                                                                  .hasIndex(RETAINED_FIELD_INDEX));
+        assertLastEventFields(console).containsEntry(RETAINED_FIELD_KEY, SOME_OTHER_VALUE);
+        assertLastEventFields(console).containsEntry(SOME_KEY, SOME_VALUE);
+    }
+
 }


### PR DESCRIPTION
SLF4J2 supports adding key-value-pairs to the event context. This PR provides support of this feature for Logback and Log4j2. It also contains a renaming of a package, that needed to be corrected.