### PR TITLE
Detect Bindings to SAP Application Logging Service

### DIFF
--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/helper/Environment.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/helper/Environment.java
@@ -7,6 +7,11 @@ public class Environment {
     public static final String LOG_REFERER = "LOG_REFERER";
     public static final String LOG_SSL_HEADERS = "LOG_SSL_HEADERS";
 
+    public static final String LOG_GENERATE_APPLICATION_LOGGING_CUSTOM_FIELDS =
+            "LOG_GENERATE_APPLICATION_LOGGING_CUSTOM_FIELDS";
+
+    public static final String VCAP_SERRVICES = "VCAP_SERVICES";
+
     public String getVariable(String name) {
         return System.getenv(name);
     }

--- a/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/serialization/SapApplicationLoggingServiceDetector.java
+++ b/cf-java-logging-support-core/src/main/java/com/sap/hcp/cf/logging/common/serialization/SapApplicationLoggingServiceDetector.java
@@ -1,0 +1,59 @@
+package com.sap.hcp.cf.logging.common.serialization;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.sap.hcp.cf.logging.common.helper.Environment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class SapApplicationLoggingServiceDetector {
+
+    private static final String VCAP_SERVICES = "VCAP_SERVICES";
+    private static final String SAP_APPLICATION_LOGGING_LABEL = "application-logs";
+    private static final Logger LOG = LoggerFactory.getLogger(SapApplicationLoggingServiceDetector.class);
+
+    private boolean boundToSapApplicationLogging;
+
+    public SapApplicationLoggingServiceDetector() {
+        this(new Environment());
+    }
+
+    SapApplicationLoggingServiceDetector(Environment environment) {
+        this(environment.getVariable(Environment.VCAP_SERRVICES));
+        String overrideString = environment.getVariable(Environment.LOG_GENERATE_APPLICATION_LOGGING_CUSTOM_FIELDS);
+        if (Boolean.parseBoolean(overrideString)) {
+            this.boundToSapApplicationLogging = true;
+        }
+    }
+
+    SapApplicationLoggingServiceDetector(String vcapServicesJson) {
+        if (vcapServicesJson == null) {
+            LOG.debug("No Cloud Foundry environment variable " + VCAP_SERVICES + " found.");
+            return;
+        }
+        try (JsonParser parser = new JsonFactory().createParser(vcapServicesJson)) {
+            parser.nextToken();
+            while (parser.nextToken() != JsonToken.END_OBJECT) {
+                String label = parser.currentName();
+                if (SAP_APPLICATION_LOGGING_LABEL.equals(label)) {
+                    this.boundToSapApplicationLogging = true;
+                    return;
+                }
+                parser.skipChildren();
+            }
+        } catch (JsonParseException e) {
+            throw new RuntimeException(e);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    public boolean isBoundToSapApplicationLogging() {
+        return boundToSapApplicationLogging;
+    }
+}

--- a/cf-java-logging-support-core/src/test/java/com/sap/hcp/cf/logging/common/serialization/ContextFieldConverterTest.java
+++ b/cf-java-logging-support-core/src/test/java/com/sap/hcp/cf/logging/common/serialization/ContextFieldConverterTest.java
@@ -1,0 +1,120 @@
+package com.sap.hcp.cf.logging.common.serialization;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.ob.JSONComposer;
+import com.fasterxml.jackson.jr.ob.comp.ObjectComposer;
+import org.assertj.core.api.AbstractStringAssert;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static com.sap.hcp.cf.logging.common.serialization.SapApplicationLoggingTestBindings.JUST_ONE_SAP_APPLICATION_LOGGING_BINDING;
+import static com.sap.hcp.cf.logging.common.serialization.SapApplicationLoggingTestBindings.NO_SAP_APPLICATION_LOGGING_BINDING;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ContextFieldConverterTest {
+
+    @Test
+    void addsRegisteredCustomFields() throws IOException {
+        ContextFieldConverter converter = new ContextFieldConverter(false, List.of("customFieldName"), emptyList(),
+                                                                    JUST_ONE_SAP_APPLICATION_LOGGING_BINDING.getDetector());
+        ObjectComposer<JSONComposer<String>> objectComposer = createObjectComposer();
+        Map<String, Object> fields = Map.of("customFieldName", "customFieldValue", "otherFieldName", "otherFieldValue");
+
+        converter.addCustomFields(objectComposer, fields);
+
+        assertJson(objectComposer).isEqualToIgnoringWhitespace(
+                "{\"#cf\":{\"string\":[{\"k\":\"customFieldName\",\"v\":\"customFieldValue\",\"i\":0}]}}");
+    }
+
+    private static ObjectComposer<JSONComposer<String>> createObjectComposer() throws IOException {
+        return new JSON().composeString().startObject();
+    }
+
+    private static AbstractStringAssert<?> assertJson(ObjectComposer<JSONComposer<String>> objectComposer)
+            throws IOException {
+        return assertThat(objectComposer.end().finish());
+    }
+
+    @Test
+    void respectsOrderingOfRegisteredCustomFields() throws IOException {
+        ContextFieldConverter converter =
+                new ContextFieldConverter(false, List.of("firstFieldName", "secondFieldName"), emptyList(),
+                                          JUST_ONE_SAP_APPLICATION_LOGGING_BINDING.getDetector());
+        ObjectComposer<JSONComposer<String>> objectComposer = createObjectComposer();
+        Map<String, Object> fields = new TreeMap<>(); // for fixed iteration order
+        fields.put("secondFieldName", "secondFieldValue"); // place second field deliberately before first
+        fields.put("firstFieldName", "firstFieldValue");
+
+        converter.addCustomFields(objectComposer, fields);
+
+        assertJson(objectComposer).isEqualToIgnoringWhitespace(
+                "{\"#cf\":{\"string\":[{\"k\":\"firstFieldName\",\"v\":\"firstFieldValue\",\"i\":0}," + "{\"k\":\"secondFieldName\",\"v\":\"secondFieldValue\",\"i\":1}]}}");
+    }
+
+    @Test
+    void doesNotCreateCustomFieldsWithoutSapApplicationLoggingBinding() throws IOException {
+        ContextFieldConverter converter = new ContextFieldConverter(false, List.of("customFieldName"), emptyList(),
+                                                                    NO_SAP_APPLICATION_LOGGING_BINDING.getDetector());
+        ObjectComposer<JSONComposer<String>> objectComposer = createObjectComposer();
+        Map<String, Object> fields = Map.of("customFieldName", "customFieldValue", "otherFieldName", "otherFieldValue");
+
+        converter.addCustomFields(objectComposer, fields);
+
+        assertJson(objectComposer).isEqualToIgnoringWhitespace("{}");
+    }
+
+    @Test
+    void addsUnregisteredFieldsAsContextFields() throws IOException {
+        ContextFieldConverter converter = new ContextFieldConverter(false, emptyList(), emptyList(),
+                                                                    JUST_ONE_SAP_APPLICATION_LOGGING_BINDING.getDetector());
+        ObjectComposer<JSONComposer<String>> objectComposer = createObjectComposer();
+        Map<String, Object> fields = Map.of("customFieldName", "customFieldValue");
+
+        converter.addContextFields(objectComposer, fields);
+
+        assertJson(objectComposer).isEqualToIgnoringWhitespace("{\"customFieldName\":\"customFieldValue\"}");
+    }
+
+    @Test
+    void doesNotAddRegisteredFieldsAsContextFields() throws IOException {
+        ContextFieldConverter converter = new ContextFieldConverter(false, List.of("customFieldName"), emptyList(),
+                                                                    JUST_ONE_SAP_APPLICATION_LOGGING_BINDING.getDetector());
+        ObjectComposer<JSONComposer<String>> objectComposer = createObjectComposer();
+        Map<String, Object> fields = Map.of("customFieldName", "customFieldValue");
+
+        converter.addContextFields(objectComposer, fields);
+
+        assertJson(objectComposer).isEqualToIgnoringWhitespace("{}");
+    }
+
+    @Test
+    void addsRetainedFieldsAsContextFields() throws IOException {
+        ContextFieldConverter converter =
+                new ContextFieldConverter(false, List.of("customFieldName"), List.of("customFieldName"),
+                                          JUST_ONE_SAP_APPLICATION_LOGGING_BINDING.getDetector());
+        ObjectComposer<JSONComposer<String>> objectComposer = createObjectComposer();
+        Map<String, Object> fields = Map.of("customFieldName", "customFieldValue");
+
+        converter.addContextFields(objectComposer, fields);
+
+        assertJson(objectComposer).isEqualToIgnoringWhitespace("{\"customFieldName\":\"customFieldValue\"}");
+    }
+
+    @Test
+    void addsRegisteredFieldsWithoutSapApplicationLoggingBindingAsContextFields() throws IOException {
+        ContextFieldConverter converter = new ContextFieldConverter(false, List.of("customFieldName"), emptyList(),
+                                                                    NO_SAP_APPLICATION_LOGGING_BINDING.getDetector());
+        ObjectComposer<JSONComposer<String>> objectComposer = createObjectComposer();
+        Map<String, Object> fields = Map.of("customFieldName", "customFieldValue");
+
+        converter.addContextFields(objectComposer, fields);
+
+        assertJson(objectComposer).isEqualToIgnoringWhitespace("{\"customFieldName\":\"customFieldValue\"}");
+    }
+
+}

--- a/cf-java-logging-support-core/src/test/java/com/sap/hcp/cf/logging/common/serialization/SapApplicationLoggingServiceDetectorTest.java
+++ b/cf-java-logging-support-core/src/test/java/com/sap/hcp/cf/logging/common/serialization/SapApplicationLoggingServiceDetectorTest.java
@@ -1,0 +1,57 @@
+package com.sap.hcp.cf.logging.common.serialization;
+
+import com.sap.hcp.cf.logging.common.helper.Environment;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static com.sap.hcp.cf.logging.common.serialization.SapApplicationLoggingTestBindings.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SapApplicationLoggingServiceDetectorTest {
+
+    @Mock
+    private Environment environment;
+
+    @Test
+    void nonCloudFoundryEnvironment() {
+        SapApplicationLoggingServiceDetector detector = new SapApplicationLoggingServiceDetector(environment);
+        assertFalse(detector.isBoundToSapApplicationLogging(), "not bound to SAP Application Logging service");
+    }
+
+    @Test
+    void emptyBindings() {
+        when(environment.getVariable(Environment.VCAP_SERRVICES)).thenReturn("{}");
+        SapApplicationLoggingServiceDetector detector = new SapApplicationLoggingServiceDetector(environment);
+        assertFalse(detector.isBoundToSapApplicationLogging(), "not bound to SAP Application Logging service");
+    }
+
+    @Test
+    void noApplicationLoggingBinding() {
+        SapApplicationLoggingServiceDetector detector = NO_SAP_APPLICATION_LOGGING_BINDING.getDetector();
+        assertFalse(detector.isBoundToSapApplicationLogging(), "not bound to SAP Application Logging service");
+    }
+
+    @Test
+    void noApplicationLoggingBindingButOverridenByEnvironment() {
+        SapApplicationLoggingServiceDetector detector = NO_SAP_APPLICATION_LOGGING_BINDING_BUT_OVERRIDE.getDetector();
+        assertTrue(detector.isBoundToSapApplicationLogging(),
+                   "not bound to SAP Application Logging service and no override");
+    }
+
+    @Test
+    void justOneApplicationLoggingBinding() {
+        SapApplicationLoggingServiceDetector detector = JUST_ONE_SAP_APPLICATION_LOGGING_BINDING.getDetector();
+        assertTrue(detector.isBoundToSapApplicationLogging(), "bound to SAP Application Logging service");
+    }
+
+    @Test
+    void mixedNoOneApplicationLoggingBinding() {
+        SapApplicationLoggingServiceDetector detector = MIXED_SAP_APPLICATION_LOGGING_AND_OTHER_BINDING.getDetector();
+        assertTrue(detector.isBoundToSapApplicationLogging(), "bound to SAP Application Logging service");
+    }
+}

--- a/cf-java-logging-support-core/src/test/java/com/sap/hcp/cf/logging/common/serialization/SapApplicationLoggingTestBindings.java
+++ b/cf-java-logging-support-core/src/test/java/com/sap/hcp/cf/logging/common/serialization/SapApplicationLoggingTestBindings.java
@@ -1,0 +1,60 @@
+package com.sap.hcp.cf.logging.common.serialization;
+
+import com.sap.hcp.cf.logging.common.helper.Environment;
+import org.junit.jupiter.api.Assertions;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public enum SapApplicationLoggingTestBindings {
+    NO_SAP_APPLICATION_LOGGING_BINDING("no-application-logging-binding.json"),
+    NO_SAP_APPLICATION_LOGGING_BINDING_BUT_OVERRIDE("no-application-logging-binding.json", true),
+    JUST_ONE_SAP_APPLICATION_LOGGING_BINDING("just-one-application-logging-binding.json"),
+    MIXED_SAP_APPLICATION_LOGGING_AND_OTHER_BINDING("mixed-no-one-application-logging-binding.json");
+
+    private SapApplicationLoggingServiceDetector detector;
+
+    SapApplicationLoggingTestBindings(String resourcePath) {
+        this(resourcePath, false);
+    }
+
+    SapApplicationLoggingTestBindings(String resourcePath, boolean assumeBinding) {
+        try {
+            String json = Files.readString(Paths.get(getClass().getResource(resourcePath).toURI()), UTF_8);
+            TestEnvironment environment = new TestEnvironment(assumeBinding, json);
+            this.detector = new SapApplicationLoggingServiceDetector(environment);
+        } catch (Exception cause) {
+            Assertions.fail("Cannot access resource " + resourcePath, cause);
+        }
+
+    }
+
+    public SapApplicationLoggingServiceDetector getDetector() {
+        return detector;
+    }
+
+    private static class TestEnvironment extends Environment {
+
+        private final boolean assumeBinding;
+        private final String vcapServices;
+
+        private TestEnvironment(boolean assumeBinding, String vcapServices) {
+
+            this.assumeBinding = assumeBinding;
+            this.vcapServices = vcapServices;
+        }
+
+        @Override
+        public String getVariable(String name) {
+            if (Environment.LOG_GENERATE_APPLICATION_LOGGING_CUSTOM_FIELDS.equals(name)) {
+                return Boolean.toString(assumeBinding);
+            }
+            if (Environment.VCAP_SERRVICES.equals(name)) {
+                return vcapServices;
+            }
+            return super.getVariable(name);
+        }
+    }
+}

--- a/cf-java-logging-support-core/src/test/resources/com/sap/hcp/cf/logging/common/serialization/just-one-application-logging-binding.json
+++ b/cf-java-logging-support-core/src/test/resources/com/sap/hcp/cf/logging/common/serialization/just-one-application-logging-binding.json
@@ -1,0 +1,18 @@
+{
+  "application-logs": [
+    {
+      "binding_guid": "6090559d-b8af-486c-bd10-51d99dfabb0d",
+      "binding_name": null,
+      "credentials": {},
+      "instance_guid": "9aabb70c-f7c0-4a2d-bf4e-223c55f04e15",
+      "instance_name": "just-one-application-logging-binding",
+      "label": "application-logs",
+      "name": "just-one-application-logging-binding",
+      "plan": "lite",
+      "provider": null,
+      "syslog_drain_url": null,
+      "tags": [],
+      "volume_mounts": []
+    }
+  ]
+}

--- a/cf-java-logging-support-core/src/test/resources/com/sap/hcp/cf/logging/common/serialization/mixed-no-one-application-logging-binding.json
+++ b/cf-java-logging-support-core/src/test/resources/com/sap/hcp/cf/logging/common/serialization/mixed-no-one-application-logging-binding.json
@@ -1,0 +1,48 @@
+{
+  "some-service": [
+    {
+      "binding_guid": "24c86662-7eb8-47c1-b1e2-119fe60afd7e",
+      "binding_name": null,
+      "credentials": {},
+      "instance_guid": "b0bd2718-ef8d-4680-a445-571dd44860d5",
+      "instance_name": "no-application-logging-binding",
+      "label": "some-service",
+      "name": "no-application-logging-binding",
+      "plan": "unknown",
+      "provider": null,
+      "syslog_drain_url": null,
+      "tags": [],
+      "volume_mounts": []
+    },
+    {
+      "binding_guid": "34c86662-7eb8-47c1-b1e2-119fe60afd7e",
+      "binding_name": null,
+      "credentials": {},
+      "instance_guid": "c0bd2718-ef8d-4680-a445-571dd44860d5",
+      "instance_name": "no-application-logging-binding",
+      "label": "some-service",
+      "name": "no-application-logging-binding",
+      "plan": "unknown2",
+      "provider": null,
+      "syslog_drain_url": null,
+      "tags": [],
+      "volume_mounts": []
+    }
+  ],
+  "application-logs": [
+    {
+      "binding_guid": "6090559d-b8af-486c-bd10-51d99dfabb0d",
+      "binding_name": null,
+      "credentials": {},
+      "instance_guid": "9aabb70c-f7c0-4a2d-bf4e-223c55f04e15",
+      "instance_name": "just-one-application-logging-binding",
+      "label": "application-logs",
+      "name": "just-one-application-logging-binding",
+      "plan": "lite",
+      "provider": null,
+      "syslog_drain_url": null,
+      "tags": [],
+      "volume_mounts": []
+    }
+  ]
+}

--- a/cf-java-logging-support-core/src/test/resources/com/sap/hcp/cf/logging/common/serialization/no-application-logging-binding.json
+++ b/cf-java-logging-support-core/src/test/resources/com/sap/hcp/cf/logging/common/serialization/no-application-logging-binding.json
@@ -1,0 +1,18 @@
+{
+  "some-service": [
+    {
+      "binding_guid": "24c86662-7eb8-47c1-b1e2-119fe60afd7e",
+      "binding_name": null,
+      "credentials": {},
+      "instance_guid": "b0bd2718-ef8d-4680-a445-571dd44860d5",
+      "instance_name": "no-application-logging-binding",
+      "label": "some-service",
+      "name": "no-application-logging-binding",
+      "plan": "unknown",
+      "provider": null,
+      "syslog_drain_url": null,
+      "tags": [],
+      "volume_mounts": []
+    }
+  ]
+}


### PR DESCRIPTION
This library generates a special format for custom fields, that is targeting SAP Application Logging Service. Since the library can also be used with other logging services most prominently SAP Cloud Logging, this special format needs to be disabled. Until now this was possible by not declaring the custom fields or also configuring them as retained fields.

This change introduces scanning of the CF service bindings for SAP Application Logging Service. It will no longer create the special format if no binding to that service is found. It is possible to force the library to always emit the old format with environment variable `LOG_GENERATE_APPLICATION_LOGGING_CUSTOM_FIELDS` set to `true`.