### PR TITLE
Remove io.pivotal.cfenv

### DIFF
--- a/cf-java-logging-support-opentelemetry-agent-extension/dependency-reduced-pom.xml
+++ b/cf-java-logging-support-opentelemetry-agent-extension/dependency-reduced-pom.xml
@@ -22,15 +22,16 @@
             <configuration>
               <filters>
                 <filter>
-                  <artifact>io.pivotal.cfenv:java-cfenv</artifact>
+                  <artifact>io.opentelemetry.contrib:opentelemetry-cloudfoundry-resources</artifact>
                   <includes>
-                    <include>io/pivotal/cfenv/**</include>
+                    <include>io/opentelemetry/contrib/cloudfoundry/resources/CloudFoundryResource.class</include>
                   </includes>
                 </filter>
               </filters>
               <artifactSet>
                 <excludes>
                   <exclude>io.opentelemetry</exclude>
+                  <exclude>io.opentelemetry.semconv</exclude>
                   <exclude>com.fasterxml.jackson.core</exclude>
                   <exclude>com.squareup.okhttp3</exclude>
                   <exclude>com.squareup.okio</exclude>
@@ -69,6 +70,24 @@
       <artifactId>opentelemetry-exporter-otlp</artifactId>
       <version>1.31.0</version>
       <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.18.2</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>uk.org.webcompere</groupId>
+      <artifactId>system-stubs-junit4</artifactId>
+      <version>2.1.8</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>system-stubs-core</artifactId>
+          <groupId>uk.org.webcompere</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/cf-java-logging-support-opentelemetry-agent-extension/pom.xml
+++ b/cf-java-logging-support-opentelemetry-agent-extension/pom.xml
@@ -55,9 +55,20 @@
             <artifactId>opentelemetry-exporter-otlp</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.pivotal.cfenv</groupId>
-            <artifactId>java-cfenv</artifactId>
-            <version>2.5.0</version>
+            <groupId>io.opentelemetry.contrib</groupId>
+            <artifactId>opentelemetry-cloudfoundry-resources</artifactId>
+            <version>1.46.0-alpha</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson-jr.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>uk.org.webcompere</groupId>
+            <artifactId>system-stubs-junit4</artifactId>
+            <version>2.1.8</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -76,15 +87,18 @@
                         <configuration>
                             <filters>
                                 <filter>
-                                    <artifact>io.pivotal.cfenv:java-cfenv</artifact>
+                                    <artifact>io.opentelemetry.contrib:opentelemetry-cloudfoundry-resources</artifact>
                                     <includes>
-                                        <include>io/pivotal/cfenv/**</include>
+                                        <include>
+                                            io/opentelemetry/contrib/cloudfoundry/resources/CloudFoundryResource.class
+                                        </include>
                                     </includes>
                                 </filter>
                             </filters>
                             <artifactSet>
                                 <excludes>
                                     <exclude>io.opentelemetry</exclude>
+                                    <exclude>io.opentelemetry.semconv</exclude>
                                     <exclude>com.fasterxml.jackson.core</exclude>
                                     <exclude>com.squareup.okhttp3</exclude>
                                     <exclude>com.squareup.okio</exclude>

--- a/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/CloudFoundryResourceProvider.java
+++ b/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/CloudFoundryResourceProvider.java
@@ -2,24 +2,16 @@ package com.sap.hcf.cf.logging.opentelemetry.agent.ext;
 
 import com.sap.hcf.cf.logging.opentelemetry.agent.ext.attributes.CloudFoundryResourceCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
-import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
 import io.opentelemetry.sdk.resources.Resource;
-import io.pivotal.cfenv.core.CfEnv;
 
-public class CloudFoundryResourceProvider implements ResourceProvider {
+public class CloudFoundryResourceProvider
+        extends io.opentelemetry.contrib.cloudfoundry.resources.CloudFoundryResourceProvider {
 
-    private final CloudFoundryResourceCustomizer customizer;
-
-    public CloudFoundryResourceProvider() {
-        this(new CfEnv());
-    }
-
-    public CloudFoundryResourceProvider(CfEnv cfEnv) {
-        this.customizer = new CloudFoundryResourceCustomizer(cfEnv);
-    }
+    private final CloudFoundryResourceCustomizer customizer = new CloudFoundryResourceCustomizer();
 
     @Override
     public Resource createResource(ConfigProperties configProperties) {
-        return customizer.apply(null, configProperties);
+        Resource original = super.createResource(configProperties);
+        return customizer.apply(original, configProperties);
     }
 }

--- a/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/CloudLoggingConfigurationCustomizerProvider.java
+++ b/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/CloudLoggingConfigurationCustomizerProvider.java
@@ -3,7 +3,6 @@ package com.sap.hcf.cf.logging.opentelemetry.agent.ext;
 import com.sap.hcf.cf.logging.opentelemetry.agent.ext.binding.CloudLoggingBindingPropertiesSupplier;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
-import io.pivotal.cfenv.core.CfEnv;
 
 import java.util.logging.Logger;
 
@@ -11,13 +10,11 @@ public class CloudLoggingConfigurationCustomizerProvider implements AutoConfigur
 
     private static final Logger LOG = Logger.getLogger(CloudLoggingConfigurationCustomizerProvider.class.getName());
     private static final String VERSION = "3.8.4";
-    private static final CfEnv cfEnv = new CfEnv();
 
     @Override
     public void customize(AutoConfigurationCustomizer autoConfiguration) {
         LOG.info("Initializing SAP BTP Observability extension " + VERSION);
-        autoConfiguration
-                .addPropertiesSupplier(new CloudLoggingBindingPropertiesSupplier());
+        autoConfiguration.addPropertiesSupplier(new CloudLoggingBindingPropertiesSupplier());
 
         // ConfigurableLogRecordExporterProvider
     }

--- a/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/attributes/CloudFoundryResourceCustomizer.java
+++ b/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/attributes/CloudFoundryResourceCustomizer.java
@@ -1,24 +1,36 @@
 package com.sap.hcf.cf.logging.opentelemetry.agent.ext.attributes;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.resources.ResourceBuilder;
-import io.pivotal.cfenv.core.CfApplication;
-import io.pivotal.cfenv.core.CfEnv;
 
-import java.util.Optional;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.logging.Logger;
 
 public class CloudFoundryResourceCustomizer implements BiFunction<Resource, ConfigProperties, Resource> {
 
-    private static final String OTEL_JAVAAGENT_EXTENSION_SAP_CF_RESOURCE_ENABLED = "otel.javaagent.extension.sap.cf.resource.enabled";
-    private static final Logger LOG = Logger.getLogger(CloudFoundryResourceCustomizer.class.getName());
-    private final CfEnv cfEnv;
+    private static final String OTEL_JAVAAGENT_EXTENSION_SAP_CF_RESOURCE_ENABLED =
+            "otel.javaagent.extension.sap.cf.resource.enabled";
 
-    public CloudFoundryResourceCustomizer(CfEnv cfEnv) {
-        this.cfEnv = cfEnv;
-    }
+    private static final String OTEL_JAVAAGENT_EXTENTION_CF_RESOURCE_FORMAT =
+            "otel.javaagent.extension.sap.cf.resource.format";
+    private static final Logger LOG = Logger.getLogger(CloudFoundryResourceCustomizer.class.getName());
+
+    private static final Map<String, String> SAP_CF_RESOURCE_ATTRIBUTES = new HashMap<String, String>() {{
+        put("cloudfoundry.app.id", "sap.cf.app_id");
+        put("cloudfoundry.app.instance.id", "sap.cf.instance_id");
+        put("cloudfoundry.app.name", "sap.cf.app_name");
+        put("cloudfoundry.org.id", "sap.cf.org_id");
+        put("cloudfoundry.org.name", "sap.cf.org_name");
+        put("cloudfoundry.process.id", "sap.cf.process.id");
+        put("cloudfoundry.process.type", "sap.cf.process.type");
+        put("cloudfoundry.space.id", "sap.cf.space_id");
+        put("cloudfoundry.space.name", "sap.cf.space_name");
+    }};
 
     @Override
     public Resource apply(Resource resource, ConfigProperties configProperties) {
@@ -27,32 +39,62 @@ public class CloudFoundryResourceCustomizer implements BiFunction<Resource, Conf
             LOG.config("CF resource attributes are disabled by configuration.");
             return Resource.empty();
         }
-        if (!cfEnv.isInCf()) {
+
+        if (resource == null || resource.getAttributes().isEmpty()) {
             LOG.config("Not running in CF. Cannot obtain CF resource attributes.");
-            return Resource.empty();
+            return resource;
         }
-        CfApplication cfApp = cfEnv.getApp();
-        ResourceBuilder rb = Resource.builder();
-        rb.put("service.name", cfApp.getApplicationName());
-        rb.put("sap.cf.source_id", cfApp.getApplicationId());
-        rb.put("sap.cf.instance_id", cfApp.getInstanceIndex());
-        rb.put("sap.cf.app_id", cfApp.getApplicationId());
-        rb.put("sap.cf.app_name", cfApp.getApplicationName());
-        rb.put("sap.cf.space_id", cfApp.getSpaceId());
-        rb.put("sap.cf.space_name", cfApp.getSpaceName());
-        rb.put("sap.cf.org_id", getString(cfApp, "organization_id"));
-        rb.put("sap.cf.org_name", getString(cfApp, "organization_name"));
-        rb.put("sap.cf.process.id", getString(cfApp, "process_id"));
-        rb.put("sap.cf.process.type", getString(cfApp, "process_type"));
-        return rb.build();
+
+        String format = configProperties.getString(OTEL_JAVAAGENT_EXTENTION_CF_RESOURCE_FORMAT, "SAP");
+        if (!format.equalsIgnoreCase("SAP")) {
+            return resource;
+        }
+
+        ResourceBuilder builder = Resource.builder();
+        resource.getAttributes().asMap().forEach(addAttribute(builder));
+        String appId = resource.getAttribute(AttributeKey.stringKey("cloudfoundry.app.id"));
+        builder.put("sap.cf.source_id", appId);
+        String appName = resource.getAttribute(AttributeKey.stringKey("cloudfoundry.app.name"));
+        String serviceName = resource.getAttribute(AttributeKey.stringKey("service.name"));
+        if (serviceName == null) {
+            builder.put("service.name", appName);
+        }
+        return builder.build();
     }
 
-    private String getString(CfApplication cfApp, String key) {
-        return Optional.ofNullable(cfApp)
-                .map(CfApplication::getMap)
-                .map(m -> m.get(key))
-                .filter(String.class::isInstance)
-                .map(String.class::cast)
-                .orElse("");
+    private BiConsumer<AttributeKey<?>, Object> addAttribute(ResourceBuilder builder) {
+        return (k, v) -> {
+            switch (k.getType()) {
+            case BOOLEAN:
+                builder.put(rename(k), (boolean) v);
+                break;
+            case BOOLEAN_ARRAY:
+                builder.put(rename(k), (boolean[]) v);
+                break;
+            case DOUBLE:
+                builder.put(rename(k), (double) v);
+                break;
+            case DOUBLE_ARRAY:
+                builder.put(rename(k), (double[]) v);
+                break;
+            case LONG:
+                builder.put(rename(k), (long) v);
+                break;
+            case LONG_ARRAY:
+                builder.put(rename(k), (long[]) v);
+                break;
+            case STRING:
+                builder.put(rename(k), (String) v);
+                break;
+            case STRING_ARRAY:
+                builder.put(rename(k), (String[]) v);
+                break;
+            }
+        };
+    }
+
+    private String rename(AttributeKey<?> key) {
+        String name = key.getKey();
+        return SAP_CF_RESOURCE_ATTRIBUTES.getOrDefault(name, name);
     }
 }

--- a/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/binding/CloudFoundryCredentials.java
+++ b/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/binding/CloudFoundryCredentials.java
@@ -1,0 +1,44 @@
+package com.sap.hcf.cf.logging.opentelemetry.agent.ext.binding;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+public class CloudFoundryCredentials {
+
+    private final Map<String, String> properties;
+
+    private CloudFoundryCredentials(Builder builder) {
+        this.properties = builder.properties;
+    }
+
+    public String getString(String key) {
+        return properties.get(key);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private final Map<String, String> properties = new TreeMap<>();
+
+        private Builder() {
+        }
+
+        public CloudFoundryCredentials build() {
+            return new CloudFoundryCredentials(this);
+        }
+
+        public Builder add(String key, String value) {
+            if (isNotBlank(key) && isNotBlank(value)) {
+                properties.put(key, value);
+            }
+            return this;
+        }
+
+        private boolean isNotBlank(String string) {
+            return string != null && !string.trim().isEmpty();
+        }
+    }
+}

--- a/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/binding/CloudFoundryServiceInstance.java
+++ b/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/binding/CloudFoundryServiceInstance.java
@@ -1,0 +1,78 @@
+package com.sap.hcf.cf.logging.opentelemetry.agent.ext.binding;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CloudFoundryServiceInstance {
+
+    private final String name;
+    private final String label;
+    private final List<String> tags;
+    private final CloudFoundryCredentials credentials;
+
+    private CloudFoundryServiceInstance(String name, String label, CloudFoundryCredentials credentials,
+                                        List<String> tags) {
+        this.name = name;
+        this.label = label;
+        this.credentials = credentials;
+        this.tags = tags;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public CloudFoundryCredentials getCredentials() {
+        return credentials;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String name;
+        private String label;
+        private final List<String> tags = new ArrayList<>();
+        private CloudFoundryCredentials credentials;
+
+        private Builder() {
+        }
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder label(String label) {
+            this.label = label;
+            return this;
+        }
+
+        public Builder tag(String tag) {
+            if (tag != null && !tag.trim().isEmpty()) {
+                tags.add(tag);
+            }
+            return this;
+        }
+
+        public Builder credentials(CloudFoundryCredentials credentials) {
+            this.credentials = credentials;
+            return this;
+        }
+
+        public CloudFoundryServiceInstance build() {
+            return new CloudFoundryServiceInstance(name, label, credentials, tags);
+        }
+
+    }
+}

--- a/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/binding/CloudFoundryServicesAdapter.java
+++ b/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/binding/CloudFoundryServicesAdapter.java
@@ -1,17 +1,37 @@
 package com.sap.hcf.cf.logging.opentelemetry.agent.ext.binding;
 
-import io.pivotal.cfenv.core.CfEnv;
-import io.pivotal.cfenv.core.CfService;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.function.Consumer;
+import java.util.logging.Logger;
 import java.util.stream.Stream;
 
 class CloudFoundryServicesAdapter {
 
-    private final CfEnv cfEnv;
+    private static final Logger LOG = Logger.getLogger(CloudFoundryServicesAdapter.class.getName());
 
-    CloudFoundryServicesAdapter(CfEnv cfEnv) {
-        this.cfEnv = cfEnv;
+    private static final String VCAP_SERVICES = "VCAP_SERVICES";
+    private static final String SERVICE_NAME = "name";
+    private static final String SERVICE_TAGS = "tags";
+    private static final String SERVICE_CREDENTIALS = "credentials";
+    private static final String SERVICE_CREDENTIALS_ENDPOINT = "ingest-otlp-endpoint";
+    private static final String SERVICE_CREDENTIALS_CLIENT_KEY = "ingest-otlp-key";
+
+    private final String vcapServicesJson;
+
+    public CloudFoundryServicesAdapter() {
+        this(System.getenv(VCAP_SERVICES));
+    }
+
+    CloudFoundryServicesAdapter(String vcapServicesJson) {
+        this.vcapServicesJson = vcapServicesJson;
     }
 
     /**
@@ -19,21 +39,132 @@ class CloudFoundryServicesAdapter {
      * check will be performed during search. User-provided service instances will be preferred unless the
      * {@code userProvidedLabel is null or empty. Provided only null values will return all service instances.
      *
-     * @param serviceLabels the labels of services
-     * @param serviceTags   the tags of services
+     * @param serviceLabels
+     *         the labels of services
+     * @param serviceTags
+     *         the tags of services
      * @return a stream of service instances present in the CloudFoundry environment variable VCAP_SERVICES
      */
-    Stream<CfService> stream(List<String> serviceLabels, List<String> serviceTags) {
-        Stream<CfService> services;
-        if (serviceLabels == null || serviceLabels.isEmpty())
-            services = cfEnv.findAllServices().stream();
-        else {
-            services = serviceLabels.stream().flatMap(l -> cfEnv.findServicesByLabel(l).stream());
+    Stream<CloudFoundryServiceInstance> stream(List<String> serviceLabels, List<String> serviceTags) {
+        if (vcapServicesJson == null) {
+            LOG.info("No environment variable " + VCAP_SERVICES + "found. Skipping service binding detection.");
+            return Stream.empty();
         }
-        if (serviceTags == null || serviceTags.isEmpty()) {
-            return services;
+        try (JsonParser parser = new JsonFactory().createParser(vcapServicesJson)) {
+            parser.nextToken();
+            List<CloudFoundryServiceInstance> services = new ArrayList<>();
+            while (parser.nextToken() != JsonToken.END_OBJECT) {
+                String label = parser.currentName();
+                if (isNullOrEmpty(serviceLabels) || serviceLabels.contains(label)) {
+                    parseServiceInstances(parser, label, serviceInstance -> {
+                        if (serviceInstance.getName() != null) {
+                            if (hasServiceTag(serviceTags, serviceInstance.getTags())) {
+                                services.add(serviceInstance);
+                            }
+                        }
+                    });
+                } else {
+                    parser.skipChildren();
+                }
+            }
+            if (isNullOrEmpty(serviceLabels)) {
+                return services.stream();
+            } else {
+                return services.stream().sorted(byLabels(serviceLabels));
+            }
+        } catch (JsonParseException cause) {
+            LOG.warning("Invalid JSON content in environment variable " + VCAP_SERVICES);
+        } catch (IOException cause) {
+            LOG.warning("Cannot parse content of environment variable " + VCAP_SERVICES);
         }
-        return services.filter(svc -> svc.existsByTagIgnoreCase(serviceTags.toArray(new String[0])));
+        return Stream.empty();
     }
 
+    private static void parseServiceInstances(JsonParser parser, String label,
+                                              Consumer<CloudFoundryServiceInstance> consumer) throws IOException {
+        if (parser.nextToken() == JsonToken.START_ARRAY) {
+            while (parser.nextToken() != JsonToken.END_ARRAY) {
+                if (parser.currentToken() == JsonToken.START_OBJECT) {
+                    CloudFoundryServiceInstance serviceInstance = parseServiceInstance(label, parser);
+                    consumer.accept(serviceInstance);
+                }
+            }
+        }
+    }
+
+    private static boolean isNullOrEmpty(List<String> items) {
+        return items == null || items.isEmpty();
+    }
+
+    private static CloudFoundryServiceInstance parseServiceInstance(String label, JsonParser parser)
+            throws IOException {
+        CloudFoundryServiceInstance.Builder builder = CloudFoundryServiceInstance.builder().label(label);
+        while (parser.nextToken() != JsonToken.END_OBJECT) {
+            switch (parser.currentName()) {
+            case SERVICE_NAME:
+                parseServiceName(builder, parser);
+                break;
+            case SERVICE_TAGS:
+                parserServiceTags(parser, builder);
+                break;
+            case SERVICE_CREDENTIALS:
+                parseServiceCredentials(parser, builder);
+                break;
+            default:
+                parser.skipChildren();
+            }
+        }
+        return builder.build();
+    }
+
+    private static void parseServiceName(CloudFoundryServiceInstance.Builder builder, JsonParser parser)
+            throws IOException {
+        builder.name(parser.getValueAsString());
+    }
+
+    private static void parserServiceTags(JsonParser parser, CloudFoundryServiceInstance.Builder builder)
+            throws IOException {
+        if (parser.nextToken() == JsonToken.START_ARRAY) {
+            while (parser.nextToken() != JsonToken.END_ARRAY) {
+                builder.tag(parser.getValueAsString());
+            }
+        }
+    }
+
+    private static void parseServiceCredentials(JsonParser parser, CloudFoundryServiceInstance.Builder builder)
+            throws IOException {
+        if (parser.nextToken() == JsonToken.START_OBJECT) {
+            CloudFoundryCredentials.Builder credentials = CloudFoundryCredentials.builder();
+            while (parser.nextToken() != JsonToken.END_OBJECT) {
+                if (parser.currentToken().isScalarValue()) {
+                    credentials.add(parser.currentName(), parser.getValueAsString());
+                } else {
+                    parser.skipChildren();
+                }
+            }
+            builder.credentials(credentials.build());
+        }
+    }
+
+    private int getIndex(List<String> serviceLabels, String label) {
+        if (label == null) {
+            return Integer.MAX_VALUE;
+        }
+        int index = serviceLabels.indexOf(label);
+        return index >= 0 ? index : Integer.MAX_VALUE;
+    }
+
+    private boolean hasServiceTag(List<String> requiredTags, List<String> instanceTags) {
+        if (isNullOrEmpty(requiredTags)) {
+            return true;
+        }
+        if (isNullOrEmpty(instanceTags)) {
+            return false;
+        }
+        return instanceTags.containsAll(requiredTags);
+    }
+
+    private Comparator<CloudFoundryServiceInstance> byLabels(List<String> serviceLabels) {
+        return (l, r) -> getIndex(serviceLabels, l.getLabel()) - getIndex(serviceLabels, r.getLabel());
+    }
 }

--- a/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/binding/CloudLoggingBindingPropertiesSupplier.java
+++ b/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/binding/CloudLoggingBindingPropertiesSupplier.java
@@ -2,8 +2,6 @@ package com.sap.hcf.cf.logging.opentelemetry.agent.ext.binding;
 
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
-import io.pivotal.cfenv.core.CfEnv;
-import io.pivotal.cfenv.core.CfService;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -26,7 +24,7 @@ public class CloudLoggingBindingPropertiesSupplier implements Supplier<Map<Strin
     private final CloudLoggingServicesProvider cloudLoggingServicesProvider;
 
     public CloudLoggingBindingPropertiesSupplier() {
-        this(new CloudLoggingServicesProvider(getDefaultProperties(), new CloudFoundryServicesAdapter(new CfEnv())));
+        this(new CloudLoggingServicesProvider(getDefaultProperties(), new CloudFoundryServicesAdapter()));
     }
 
     CloudLoggingBindingPropertiesSupplier(CloudLoggingServicesProvider cloudLoggingServicesProvider) {
@@ -56,21 +54,19 @@ public class CloudLoggingBindingPropertiesSupplier implements Supplier<Map<Strin
     }
 
     /**
-     * Scans service bindings, both managed and user-provided for Cloud Logging.
-     * Managed services require the label "cloud-logging" to be considered.
-     * Services will be selected by the tag "Cloud Logging".
-     * User-provided services will be preferred over managed service instances.
+     * Scans service bindings, both managed and user-provided for Cloud Logging. Managed services require the label
+     * "cloud-logging" to be considered. Services will be selected by the tag "Cloud Logging". User-provided services
+     * will be preferred over managed service instances.
      *
      * @return The pre-configured connection properties for the OpenTelemetry SDK.
      */
     @Override
     public Map<String, String> get() {
-        return cloudLoggingServicesProvider.get()
-                .findFirst()
-                .map(this::createEndpointConfiguration).orElseGet(Collections::emptyMap);
+        return cloudLoggingServicesProvider.get().findFirst().map(this::createEndpointConfiguration)
+                                           .orElseGet(Collections::emptyMap);
     }
 
-    private Map<String, String> createEndpointConfiguration(CfService svc) {
+    private Map<String, String> createEndpointConfiguration(CloudFoundryServiceInstance svc) {
         LOG.config("Using service " + svc.getName() + " (" + svc.getLabel() + ")");
 
         String endpoint = svc.getCredentials().getString(OTLP_ENDPOINT);

--- a/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/binding/CloudLoggingServicesProvider.java
+++ b/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/binding/CloudLoggingServicesProvider.java
@@ -1,8 +1,6 @@
 package com.sap.hcf.cf.logging.opentelemetry.agent.ext.binding;
 
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
-import io.pivotal.cfenv.core.CfEnv;
-import io.pivotal.cfenv.core.CfService;
 
 import java.util.List;
 import java.util.function.Supplier;
@@ -12,16 +10,16 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 
-public class CloudLoggingServicesProvider implements Supplier<Stream<CfService>> {
+public class CloudLoggingServicesProvider implements Supplier<Stream<CloudFoundryServiceInstance>> {
 
     private static final String DEFAULT_USER_PROVIDED_LABEL = "user-provided";
     private static final String DEFAULT_CLOUD_LOGGING_LABEL = "cloud-logging";
     private static final String DEFAULT_CLOUD_LOGGING_TAG = "Cloud Logging";
 
-    private final List<CfService> services;
+    private final List<CloudFoundryServiceInstance> services;
 
     public CloudLoggingServicesProvider(ConfigProperties config) {
-        this(config, new CloudFoundryServicesAdapter(new CfEnv()));
+        this(config, new CloudFoundryServicesAdapter());
     }
 
     CloudLoggingServicesProvider(ConfigProperties config, CloudFoundryServicesAdapter adapter) {
@@ -31,21 +29,24 @@ public class CloudLoggingServicesProvider implements Supplier<Stream<CfService>>
     }
 
     private String getUserProvidedLabel(ConfigProperties config) {
-        return config.getString("otel.javaagent.extension.sap.cf.binding.user-provided.label", DEFAULT_USER_PROVIDED_LABEL);
+        return config.getString("otel.javaagent.extension.sap.cf.binding.user-provided.label",
+                                DEFAULT_USER_PROVIDED_LABEL);
     }
 
     private String getCloudLoggingLabel(ConfigProperties config) {
-        String fromOwnProperties = System.getProperty("com.sap.otel.extension.cloud-logging.label", DEFAULT_CLOUD_LOGGING_LABEL);
+        String fromOwnProperties =
+                System.getProperty("com.sap.otel.extension.cloud-logging.label", DEFAULT_CLOUD_LOGGING_LABEL);
         return config.getString("otel.javaagent.extension.sap.cf.binding.cloud-logging.label", fromOwnProperties);
     }
 
     private String getCloudLoggingTag(ConfigProperties config) {
-        String fromOwnProperties = System.getProperty("com.sap.otel.extension.cloud-logging.tag", DEFAULT_CLOUD_LOGGING_TAG);
+        String fromOwnProperties =
+                System.getProperty("com.sap.otel.extension.cloud-logging.tag", DEFAULT_CLOUD_LOGGING_TAG);
         return config.getString("otel.javaagent.extension.sap.cf.binding.cloud-logging.tag", fromOwnProperties);
     }
 
     @Override
-    public Stream<CfService> get() {
+    public Stream<CloudFoundryServiceInstance> get() {
         return services.stream();
     }
 }

--- a/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/binding/DynatraceServiceProvider.java
+++ b/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/binding/DynatraceServiceProvider.java
@@ -1,8 +1,6 @@
 package com.sap.hcf.cf.logging.opentelemetry.agent.ext.binding;
 
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
-import io.pivotal.cfenv.core.CfEnv;
-import io.pivotal.cfenv.core.CfService;
 
 import java.util.List;
 import java.util.function.Supplier;
@@ -10,16 +8,16 @@ import java.util.function.Supplier;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 
-public class DynatraceServiceProvider implements Supplier<CfService> {
+public class DynatraceServiceProvider implements Supplier<CloudFoundryServiceInstance> {
 
     private static final String DEFAULT_USER_PROVIDED_LABEL = "user-provided";
     private static final String DEFAULT_DYNATRACE_LABEL = "dynatrace";
     private static final String DEFAULT_DYNATRACE_TAG = "dynatrace";
 
-    private final CfService service;
+    private final CloudFoundryServiceInstance service;
 
     public DynatraceServiceProvider(ConfigProperties config) {
-        this(config, new CloudFoundryServicesAdapter(new CfEnv()));
+        this(config, new CloudFoundryServicesAdapter());
     }
 
     DynatraceServiceProvider(ConfigProperties config, CloudFoundryServicesAdapter adapter) {
@@ -29,7 +27,8 @@ public class DynatraceServiceProvider implements Supplier<CfService> {
     }
 
     private String getUserProvidedLabel(ConfigProperties config) {
-        return config.getString("otel.javaagent.extension.sap.cf.binding.user-provided.label", DEFAULT_USER_PROVIDED_LABEL);
+        return config.getString("otel.javaagent.extension.sap.cf.binding.user-provided.label",
+                                DEFAULT_USER_PROVIDED_LABEL);
     }
 
     private String getDynatraceLabel(ConfigProperties config) {
@@ -41,7 +40,7 @@ public class DynatraceServiceProvider implements Supplier<CfService> {
     }
 
     @Override
-    public CfService get() {
+    public CloudFoundryServiceInstance get() {
         return service;
     }
 }

--- a/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/exporter/CloudLoggingCredentials.java
+++ b/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/exporter/CloudLoggingCredentials.java
@@ -1,11 +1,11 @@
 package com.sap.hcf.cf.logging.opentelemetry.agent.ext.exporter;
 
-import io.pivotal.cfenv.core.CfCredentials;
+import com.sap.hcf.cf.logging.opentelemetry.agent.ext.binding.CloudFoundryCredentials;
 
 import java.nio.charset.StandardCharsets;
 import java.util.logging.Logger;
 
-class CloudLoggingCredentials {
+public class CloudLoggingCredentials {
 
     private static final Logger LOG = Logger.getLogger(CloudLoggingCredentials.class.getName());
 
@@ -16,7 +16,6 @@ class CloudLoggingCredentials {
     private static final String CRED_OTLP_CLIENT_CERT = "ingest-otlp-cert";
     private static final String CRED_OTLP_SERVER_CERT = "server-ca";
     private static final String CLOUD_LOGGING_ENDPOINT_PREFIX = "https://";
-
 
     private String endpoint;
     private byte[] clientKey;
@@ -30,8 +29,12 @@ class CloudLoggingCredentials {
         return PARSER;
     }
 
-    private static byte[] getPEMBytes(CfCredentials credentials, String key) {
+    private static byte[] getPEMBytes(CloudFoundryCredentials credentials, String key) {
         String raw = credentials.getString(key);
+        return getPEMBytes(raw);
+    }
+
+    private static byte[] getPEMBytes(String raw) {
         return raw == null ? null : raw.trim().replace("\\n", "\n").getBytes(StandardCharsets.UTF_8);
     }
 
@@ -45,22 +48,26 @@ class CloudLoggingCredentials {
 
     public boolean validate() {
         if (isBlank(endpoint)) {
-            LOG.warning("Credential \"" + CRED_OTLP_ENDPOINT + "\" not found. Skipping cloud-logging exporter configuration");
+            LOG.warning(
+                    "Credential \"" + CRED_OTLP_ENDPOINT + "\" not found. Skipping cloud-logging exporter configuration");
             return false;
         }
 
         if (isNullOrEmpty(clientKey)) {
-            LOG.warning("Credential \"" + CRED_OTLP_CLIENT_KEY + "\" not found. Skipping cloud-logging exporter configuration");
+            LOG.warning(
+                    "Credential \"" + CRED_OTLP_CLIENT_KEY + "\" not found. Skipping cloud-logging exporter configuration");
             return false;
         }
 
         if (isNullOrEmpty(clientCert)) {
-            LOG.warning("Credential \"" + CRED_OTLP_CLIENT_CERT + "\" not found. Skipping cloud-logging exporter configuration");
+            LOG.warning(
+                    "Credential \"" + CRED_OTLP_CLIENT_CERT + "\" not found. Skipping cloud-logging exporter configuration");
             return false;
         }
 
         if (isNullOrEmpty(serverCert)) {
-            LOG.warning("Credential \"" + CRED_OTLP_SERVER_CERT + "\" not found. Skipping cloud-logging exporter configuration");
+            LOG.warning(
+                    "Credential \"" + CRED_OTLP_SERVER_CERT + "\" not found. Skipping cloud-logging exporter configuration");
             return false;
         }
         return true;
@@ -83,7 +90,7 @@ class CloudLoggingCredentials {
     }
 
     static class Parser {
-        CloudLoggingCredentials parse(CfCredentials cfCredentials) {
+        CloudLoggingCredentials parse(CloudFoundryCredentials cfCredentials) {
             CloudLoggingCredentials parsed = new CloudLoggingCredentials();
             String rawEndpoint = cfCredentials.getString(CRED_OTLP_ENDPOINT);
             parsed.endpoint = isBlank(rawEndpoint) ? null : CLOUD_LOGGING_ENDPOINT_PREFIX + rawEndpoint;

--- a/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/exporter/CloudLoggingLogsExporterProvider.java
+++ b/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/exporter/CloudLoggingLogsExporterProvider.java
@@ -1,5 +1,6 @@
 package com.sap.hcf.cf.logging.opentelemetry.agent.ext.exporter;
 
+import com.sap.hcf.cf.logging.opentelemetry.agent.ext.binding.CloudFoundryServiceInstance;
 import com.sap.hcf.cf.logging.opentelemetry.agent.ext.binding.CloudLoggingServicesProvider;
 import io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporter;
 import io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporterBuilder;
@@ -7,7 +8,6 @@ import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider;
 import io.opentelemetry.sdk.common.export.RetryPolicy;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
-import io.pivotal.cfenv.core.CfService;
 
 import java.time.Duration;
 import java.util.List;
@@ -20,14 +20,15 @@ public class CloudLoggingLogsExporterProvider implements ConfigurableLogRecordEx
 
     private static final Logger LOG = Logger.getLogger(CloudLoggingLogsExporterProvider.class.getName());
 
-    private final Function<ConfigProperties, Stream<CfService>> servicesProvider;
+    private final Function<ConfigProperties, Stream<CloudFoundryServiceInstance>> servicesProvider;
     private final CloudLoggingCredentials.Parser credentialParser;
 
     public CloudLoggingLogsExporterProvider() {
         this(config -> new CloudLoggingServicesProvider(config).get(), CloudLoggingCredentials.parser());
     }
 
-    CloudLoggingLogsExporterProvider(Function<ConfigProperties, Stream<CfService>> serviceProvider, CloudLoggingCredentials.Parser credentialParser) {
+    CloudLoggingLogsExporterProvider(Function<ConfigProperties, Stream<CloudFoundryServiceInstance>> serviceProvider,
+                                     CloudLoggingCredentials.Parser credentialParser) {
         this.servicesProvider = serviceProvider;
         this.credentialParser = credentialParser;
     }
@@ -49,14 +50,13 @@ public class CloudLoggingLogsExporterProvider implements ConfigurableLogRecordEx
 
     @Override
     public LogRecordExporter createExporter(ConfigProperties config) {
-        List<LogRecordExporter> exporters = servicesProvider.apply(config)
-                .map(svc -> createExporter(config, svc))
-                .filter(exp -> !(exp instanceof NoopLogRecordExporter))
-                .collect(Collectors.toList());
+        List<LogRecordExporter> exporters = servicesProvider.apply(config).map(svc -> createExporter(config, svc))
+                                                            .filter(exp -> !(exp instanceof NoopLogRecordExporter))
+                                                            .collect(Collectors.toList());
         return LogRecordExporter.composite(exporters);
     }
 
-    private LogRecordExporter createExporter(ConfigProperties config, CfService service) {
+    private LogRecordExporter createExporter(ConfigProperties config, CloudFoundryServiceInstance service) {
         LOG.info("Creating logs exporter for service binding " + service.getName() + " (" + service.getLabel() + ")");
         CloudLoggingCredentials credentials = credentialParser.parse(service.getCredentials());
         if (!credentials.validate()) {
@@ -64,11 +64,9 @@ public class CloudLoggingLogsExporterProvider implements ConfigurableLogRecordEx
         }
 
         OtlpGrpcLogRecordExporterBuilder builder = OtlpGrpcLogRecordExporter.builder();
-        builder.setEndpoint(credentials.getEndpoint())
-                .setCompression(getCompression(config))
-                .setClientTls(credentials.getClientKey(), credentials.getClientCert())
-                .setTrustedCertificates(credentials.getServerCert())
-                .setRetryPolicy(RetryPolicy.getDefault());
+        builder.setEndpoint(credentials.getEndpoint()).setCompression(getCompression(config))
+               .setClientTls(credentials.getClientKey(), credentials.getClientCert())
+               .setTrustedCertificates(credentials.getServerCert()).setRetryPolicy(RetryPolicy.getDefault());
 
         Duration timeOut = getTimeOut(config);
         if (timeOut != null) {

--- a/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/exporter/CloudLoggingSpanExporterProvider.java
+++ b/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/exporter/CloudLoggingSpanExporterProvider.java
@@ -1,5 +1,6 @@
 package com.sap.hcf.cf.logging.opentelemetry.agent.ext.exporter;
 
+import com.sap.hcf.cf.logging.opentelemetry.agent.ext.binding.CloudFoundryServiceInstance;
 import com.sap.hcf.cf.logging.opentelemetry.agent.ext.binding.CloudLoggingServicesProvider;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporterBuilder;
@@ -7,8 +8,6 @@ import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
 import io.opentelemetry.sdk.common.export.RetryPolicy;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
-import io.pivotal.cfenv.core.CfCredentials;
-import io.pivotal.cfenv.core.CfService;
 
 import java.time.Duration;
 import java.util.List;
@@ -21,14 +20,15 @@ public class CloudLoggingSpanExporterProvider implements ConfigurableSpanExporte
 
     private static final Logger LOG = Logger.getLogger(CloudLoggingSpanExporterProvider.class.getName());
 
-    private final Function<ConfigProperties, Stream<CfService>> servicesProvider;
+    private final Function<ConfigProperties, Stream<CloudFoundryServiceInstance>> servicesProvider;
     private final CloudLoggingCredentials.Parser credentialParser;
 
     public CloudLoggingSpanExporterProvider() {
         this(config -> new CloudLoggingServicesProvider(config).get(), CloudLoggingCredentials.parser());
     }
 
-    CloudLoggingSpanExporterProvider(Function<ConfigProperties, Stream<CfService>> serviceProvider, CloudLoggingCredentials.Parser credentialParser) {
+    CloudLoggingSpanExporterProvider(Function<ConfigProperties, Stream<CloudFoundryServiceInstance>> serviceProvider,
+                                     CloudLoggingCredentials.Parser credentialParser) {
         this.servicesProvider = serviceProvider;
         this.credentialParser = credentialParser;
     }
@@ -50,27 +50,23 @@ public class CloudLoggingSpanExporterProvider implements ConfigurableSpanExporte
 
     @Override
     public SpanExporter createExporter(ConfigProperties config) {
-        List<SpanExporter> exporters = servicesProvider.apply(config)
-                .map(svc -> createExporter(config, svc))
-                .filter(exp -> !(exp instanceof NoopSpanExporter))
-                .collect(Collectors.toList());
+        List<SpanExporter> exporters = servicesProvider.apply(config).map(svc -> createExporter(config, svc))
+                                                       .filter(exp -> !(exp instanceof NoopSpanExporter))
+                                                       .collect(Collectors.toList());
         return SpanExporter.composite(exporters);
     }
 
-    private SpanExporter createExporter(ConfigProperties config, CfService service) {
+    private SpanExporter createExporter(ConfigProperties config, CloudFoundryServiceInstance service) {
         LOG.info("Creating span exporter for service binding " + service.getName() + " (" + service.getLabel() + ")");
-        CfCredentials cfCredentials = service.getCredentials();
-        CloudLoggingCredentials credentials = credentialParser.parse(cfCredentials);
+        CloudLoggingCredentials credentials = credentialParser.parse(service.getCredentials());
         if (!credentials.validate()) {
             return NoopSpanExporter.getInstance();
         }
 
         OtlpGrpcSpanExporterBuilder builder = OtlpGrpcSpanExporter.builder();
-        builder.setEndpoint(credentials.getEndpoint())
-                .setCompression(getCompression(config))
-                .setClientTls(credentials.getClientKey(), credentials.getClientCert())
-                .setTrustedCertificates(credentials.getServerCert())
-                .setRetryPolicy(RetryPolicy.getDefault());
+        builder.setEndpoint(credentials.getEndpoint()).setCompression(getCompression(config))
+               .setClientTls(credentials.getClientKey(), credentials.getClientCert())
+               .setTrustedCertificates(credentials.getServerCert()).setRetryPolicy(RetryPolicy.getDefault());
 
         Duration timeOut = getTimeOut(config);
         if (timeOut != null) {

--- a/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/exporter/DynatraceMetricsExporterProvider.java
+++ b/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/exporter/DynatraceMetricsExporterProvider.java
@@ -1,5 +1,7 @@
 package com.sap.hcf.cf.logging.opentelemetry.agent.ext.exporter;
 
+import com.sap.hcf.cf.logging.opentelemetry.agent.ext.binding.CloudFoundryCredentials;
+import com.sap.hcf.cf.logging.opentelemetry.agent.ext.binding.CloudFoundryServiceInstance;
 import com.sap.hcf.cf.logging.opentelemetry.agent.ext.binding.DynatraceServiceProvider;
 import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter;
 import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder;
@@ -14,7 +16,6 @@ import io.opentelemetry.sdk.metrics.export.AggregationTemporalitySelector;
 import io.opentelemetry.sdk.metrics.export.DefaultAggregationSelector;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import io.opentelemetry.sdk.metrics.internal.aggregator.AggregationUtil;
-import io.pivotal.cfenv.core.CfService;
 
 import java.time.Duration;
 import java.util.Locale;
@@ -29,13 +30,13 @@ public class DynatraceMetricsExporterProvider implements ConfigurableMetricExpor
     public static final String DT_APIURL_METRICS_SUFFIX = "/v2/otlp/v1/metrics";
     private static final Logger LOG = Logger.getLogger(DynatraceMetricsExporterProvider.class.getName());
     private static final AggregationTemporalitySelector ALWAYS_DELTA = instrumentType -> AggregationTemporality.DELTA;
-    private final Function<ConfigProperties, CfService> serviceProvider;
+    private final Function<ConfigProperties, CloudFoundryServiceInstance> serviceProvider;
 
     public DynatraceMetricsExporterProvider() {
         this(config -> new DynatraceServiceProvider(config).get());
     }
 
-    public DynatraceMetricsExporterProvider(Function<ConfigProperties, CfService> serviceProvider) {
+    public DynatraceMetricsExporterProvider(Function<ConfigProperties, CloudFoundryServiceInstance> serviceProvider) {
         this.serviceProvider = serviceProvider;
     }
 
@@ -101,7 +102,7 @@ public class DynatraceMetricsExporterProvider implements ConfigurableMetricExpor
 
     @Override
     public MetricExporter createExporter(ConfigProperties config) {
-        CfService cfService = serviceProvider.apply(config);
+        CloudFoundryServiceInstance cfService = serviceProvider.apply(config);
         if (cfService == null) {
             LOG.info("No dynatrace service binding found. Skipping metrics exporter registration.");
             return NoopMetricExporter.getInstance();
@@ -110,7 +111,12 @@ public class DynatraceMetricsExporterProvider implements ConfigurableMetricExpor
         LOG.info(
                 "Creating metrics exporter for service binding " + cfService.getName() + " (" + cfService.getLabel() + ")");
 
-        String apiUrl = cfService.getCredentials().getString(CRED_DYNATRACE_APIURL);
+        CloudFoundryCredentials credentials = cfService.getCredentials();
+        if (credentials == null) {
+            LOG.warning("No credentials found Skipping dynatrace exporter configuration");
+            return NoopMetricExporter.getInstance();
+        }
+        String apiUrl = credentials.getString(CRED_DYNATRACE_APIURL);
         if (isBlank(apiUrl)) {
             LOG.warning(
                     "Credential \"" + CRED_DYNATRACE_APIURL + "\" not found. Skipping dynatrace exporter configuration");
@@ -122,7 +128,7 @@ public class DynatraceMetricsExporterProvider implements ConfigurableMetricExpor
                     "Configuration \"otel.javaagent.extension.sap.cf.binding.dynatrace.metrics.token-name\" not found. Skipping dynatrace exporter configuration");
             return NoopMetricExporter.getInstance();
         }
-        String apiToken = cfService.getCredentials().getString(tokenName);
+        String apiToken = credentials.getString(tokenName);
         if (isBlank(apiUrl)) {
             LOG.warning("Credential \"" + tokenName + "\" not found. Skipping dynatrace exporter configuration");
             return NoopMetricExporter.getInstance();

--- a/cf-java-logging-support-opentelemetry-agent-extension/src/test/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/CloudFoundryResourceProviderTest.java
+++ b/cf-java-logging-support-opentelemetry-agent-extension/src/test/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/CloudFoundryResourceProviderTest.java
@@ -1,22 +1,55 @@
 package com.sap.hcf.cf.logging.opentelemetry.agent.ext;
 
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
+import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
+import io.opentelemetry.sdk.resources.Resource;
+import org.junit.Rule;
 import org.junit.Test;
+import uk.org.webcompere.systemstubs.rules.EnvironmentVariablesRule;
 
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.ServiceLoader;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class CloudFoundryResourceProviderTest {
+
+    @Rule
+    public EnvironmentVariablesRule environmentVariablesRule = new EnvironmentVariablesRule();
 
     @Test
     public void canLoadViaSPI() {
         ServiceLoader<ResourceProvider> loader = ServiceLoader.load(ResourceProvider.class);
         Stream<ResourceProvider> providers = StreamSupport.stream(loader.spliterator(), false);
         assertTrue(CloudFoundryResourceProvider.class.getName() + " not loaded via SPI",
-                providers.anyMatch(p -> p instanceof CloudFoundryResourceProvider));
+                   providers.anyMatch(p -> p instanceof CloudFoundryResourceProvider));
     }
 
+    @Test
+    public void generatesResource() throws Exception {
+        String vcapApplication =
+                new String(Files.readAllBytes(Paths.get(getClass().getResource("vcap_application.json").toURI())));
+        environmentVariablesRule.set("VCAP_APPLICATION", vcapApplication);
+
+        CloudFoundryResourceProvider provider = new CloudFoundryResourceProvider();
+        Resource resource = provider.createResource(DefaultConfigProperties.createFromMap(Collections.emptyMap()));
+
+        assertEquals("test-app-id", resource.getAttribute(AttributeKey.stringKey("sap.cf.app_id")));
+        assertEquals("test-application", resource.getAttribute(AttributeKey.stringKey("sap.cf.app_name")));
+        assertEquals("42", resource.getAttribute(AttributeKey.stringKey("sap.cf.instance_id")));
+        assertEquals("test-org-id", resource.getAttribute(AttributeKey.stringKey("sap.cf.org_id")));
+        assertEquals("test-org", resource.getAttribute(AttributeKey.stringKey("sap.cf.org_name")));
+        assertEquals("test-process-id", resource.getAttribute(AttributeKey.stringKey("sap.cf.process.id")));
+        assertEquals("test-process-type", resource.getAttribute(AttributeKey.stringKey("sap.cf.process.type")));
+        assertEquals("test-app-id", resource.getAttribute(AttributeKey.stringKey("sap.cf.source_id")));
+        assertEquals("test-space-id", resource.getAttribute(AttributeKey.stringKey("sap.cf.space_id")));
+        assertEquals("test-space", resource.getAttribute(AttributeKey.stringKey("sap.cf.space_name")));
+        assertEquals("test-application", resource.getAttribute(AttributeKey.stringKey("service.name")));
+    }
 }

--- a/cf-java-logging-support-opentelemetry-agent-extension/src/test/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/attributes/CloudFoundryResourceCustomizerTest.java
+++ b/cf-java-logging-support-opentelemetry-agent-extension/src/test/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/attributes/CloudFoundryResourceCustomizerTest.java
@@ -3,63 +3,67 @@ package com.sap.hcf.cf.logging.opentelemetry.agent.ext.attributes;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
 import io.opentelemetry.sdk.resources.Resource;
-import io.pivotal.cfenv.core.CfApplication;
-import io.pivotal.cfenv.core.CfEnv;
 import org.junit.Test;
-import org.mockito.Mockito;
 
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
 
 public class CloudFoundryResourceCustomizerTest {
 
+    private static final Resource DEFAULT_CF_RESOURCE =
+            Resource.builder().put("cloudfoundry.app.id", "test-app-id").put("cloudfoundry.app.instance.id", "42")
+                    .put("cloudfoundry.app.name", "test-application").put("cloudfoundry.org.id", "test-org-id")
+                    .put("cloudfoundry.org.name", "test-org").put("cloudfoundry.process.id", "test-process-id")
+                    .put("cloudfoundry.process.type", "test-process-type").put("cloudfoundry.space.id", "test-space-id")
+                    .put("cloudfoundry.space.name", "test-space").build();
+
     @Test
     public void emptyResourceWhenNotInCf() {
-        CloudFoundryResourceCustomizer customizer = new CloudFoundryResourceCustomizer(new CfEnv());
-        Resource resource = customizer.apply(Resource.builder().build(), DefaultConfigProperties.create(new HashMap<>()));
+        CloudFoundryResourceCustomizer customizer = new CloudFoundryResourceCustomizer();
+        Resource resource =
+                customizer.apply(Resource.builder().build(), DefaultConfigProperties.create(new HashMap<>()));
         assertTrue(resource.getAttributes().isEmpty());
     }
 
     @Test
     public void emptyResourceWhenDisabledByProperty() {
-        CfEnv cfEnv = Mockito.mock(CfEnv.class);
-        when(cfEnv.isInCf()).thenReturn(true);
 
         HashMap<String, String> properties = new HashMap<>();
         properties.put("otel.javaagent.extension.sap.cf.resource.enabled", "false");
 
-        CloudFoundryResourceCustomizer customizer = new CloudFoundryResourceCustomizer(cfEnv);
+        CloudFoundryResourceCustomizer customizer = new CloudFoundryResourceCustomizer();
         Resource resource = customizer.apply(Resource.builder().build(), DefaultConfigProperties.create(properties));
         assertTrue(resource.getAttributes().isEmpty());
     }
 
     @Test
     public void fillsResourceFromVcapApplication() {
-        CfEnv cfEnv = Mockito.mock(CfEnv.class);
-        when(cfEnv.isInCf()).thenReturn(true);
-        Map<String, Object> applicationData = new HashMap<>();
-        applicationData.put("application_name", "test-application");
-        applicationData.put("space_name", "test-space");
-        applicationData.put("organization_name", "test-org");
-        applicationData.put("application_id", "test-app-id");
-        applicationData.put("instance_index", 42);
-        applicationData.put("process_id", "test-process-id");
-        applicationData.put("process_type", "test-process-type");
-        when(cfEnv.getApp()).thenReturn(new CfApplication(applicationData));
-
-        CloudFoundryResourceCustomizer customizer = new CloudFoundryResourceCustomizer(cfEnv);
-        Resource resource = customizer.apply(Resource.builder().build(), DefaultConfigProperties.create(new HashMap<>()));
+        CloudFoundryResourceCustomizer customizer = new CloudFoundryResourceCustomizer();
+        Resource resource =
+                customizer.apply(DEFAULT_CF_RESOURCE, DefaultConfigProperties.create(Collections.emptyMap()));
         assertEquals("test-application", resource.getAttribute(AttributeKey.stringKey("service.name")));
         assertEquals("test-application", resource.getAttribute(AttributeKey.stringKey("sap.cf.app_name")));
+        assertEquals("test-app-id", resource.getAttribute(AttributeKey.stringKey("sap.cf.app_id")));
         assertEquals("test-space", resource.getAttribute(AttributeKey.stringKey("sap.cf.space_name")));
         assertEquals("test-org", resource.getAttribute(AttributeKey.stringKey("sap.cf.org_name")));
-        assertEquals("test-app-id", resource.getAttribute(AttributeKey.stringKey("sap.cf.source_id")));
-        assertEquals(42, resource.getAttribute(AttributeKey.longKey("sap.cf.instance_id")).longValue());
+        assertEquals("42", resource.getAttribute(AttributeKey.stringKey("sap.cf.instance_id")));
         assertEquals("test-process-id", resource.getAttribute(AttributeKey.stringKey("sap.cf.process.id")));
         assertEquals("test-process-type", resource.getAttribute(AttributeKey.stringKey("sap.cf.process.type")));
+        assertEquals("test-app-id", resource.getAttribute(AttributeKey.stringKey("sap.cf.source_id")));
+        assertEquals("test-application", resource.getAttribute(AttributeKey.stringKey("service.name")));
+    }
+
+    @Test
+    public void keepsOriginalResourceOnOTelResourceFormat() {
+        CloudFoundryResourceCustomizer customizer = new CloudFoundryResourceCustomizer();
+        HashMap<String, String> config = new HashMap<String, String>() {{
+            put("otel.javaagent.extension.sap.cf.resource.format", "opentelemetry");
+        }};
+        Resource resource = customizer.apply(DEFAULT_CF_RESOURCE, DefaultConfigProperties.create(config));
+
+        assertEquals(DEFAULT_CF_RESOURCE, resource);
     }
 }

--- a/cf-java-logging-support-opentelemetry-agent-extension/src/test/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/binding/CloudFoundryServicesAdapterTest.java
+++ b/cf-java-logging-support-opentelemetry-agent-extension/src/test/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/binding/CloudFoundryServicesAdapterTest.java
@@ -1,7 +1,5 @@
 package com.sap.hcf.cf.logging.opentelemetry.agent.ext.binding;
 
-import io.pivotal.cfenv.core.CfEnv;
-import io.pivotal.cfenv.core.CfService;
 import org.hamcrest.FeatureMatcher;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
@@ -16,31 +14,29 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 public class CloudFoundryServicesAdapterTest {
-    private static final String DEFAULT_VCAP_APPLICATION = "{}";
-    private static final String DEFAULT_VCAP_SERVICES = "{" +
-            "\"managed-find-me-service\":[" +
-            "{\"label\":\"managed-find-me-service\", \"tags\":[\"Find Me!\"],\"name\":\"managed-find-me1\"}," +
-            "{\"label\":\"managed-find-me-service\", \"tags\":[\"Find Me!\"],\"name\":\"managed-find-me2\"}," +
-            "{\"label\":\"managed-find-me-service\", \"tags\":[\"You can't see me!\"],\"name\":\"managed-other\"}" +
-            "]," +
-            "\"managed-notice-me-not-service\":[" +
-            "{\"label\":\"managed-notice-me-not-service\", \"tags\":[\"Find Me!\"],\"name\":\"managed-other1\"}," +
-            "{\"label\":\"managed-notice-me-not-service\", \"tags\":[\"You can't see me!\"],\"name\":\"managed-other2\"}" +
-            "]," +
-            "\"user-provided\":[" +
-            "{\"label\":\"user-provided\", \"tags\":[\"Find Me!\"],\"name\":\"ups-find-me1\"}," +
-            "{\"label\":\"user-provided\", \"tags\":[\"Find Me!\"],\"name\":\"ups-find-me2\"}," +
-            "{\"label\":\"user-provided\", \"tags\":[\"You can't see me!\"],\"name\":\"ups-other\"}" +
-            "]}";
+    private static final String DEFAULT_VCAP_SERVICES = "{" + "\"managed-find-me-service\":[" //
+            + "{\"label\":\"managed-find-me-service\", \"tags\":[\"Find Me!\"],\"name\":\"managed-find-me1\"}," //
+            + "{\"label\":\"managed-find-me-service\", \"tags\":[\"Find Me!\"],\"name\":\"managed-find-me2\"}," //
+            + "{\"label\":\"managed-find-me-service\", \"tags\":[\"You can't see me!\"],\"name\":\"managed-other\"}" //
+            + "]," //
+            + "\"managed-notice-me-not-service\":[" //
+            + "{\"label\":\"managed-notice-me-not-service\", \"tags\":[\"Find Me!\"],\"name\":\"managed-other1\"}," //
+            + "{\"label\":\"managed-notice-me-not-service\", \"tags\":[\"You can't see me!\"],\"name\":\"managed-other2\"}" //
+            + "]," //
+            + "\"user-provided\":[" //
+            + "{\"label\":\"user-provided\", \"tags\":[\"Find Me!\"],\"name\":\"ups-find-me1\"}," //
+            + "{\"label\":\"user-provided\", \"tags\":[\"Find Me!\"],\"name\":\"ups-find-me2\"}," //
+            + "{\"label\":\"user-provided\", \"tags\":[\"You can't see me!\"],\"name\":\"ups-other\"}" //
+            + "]}";
 
-    private static final CfEnv DEFAULT_CF_ENV = new CfEnv(DEFAULT_VCAP_APPLICATION, DEFAULT_VCAP_SERVICES);
-    private static final CloudFoundryServicesAdapter DEFAULT_ADAPTER = new CloudFoundryServicesAdapter(DEFAULT_CF_ENV);
+    private static final CloudFoundryServicesAdapter DEFAULT_ADAPTER =
+            new CloudFoundryServicesAdapter(DEFAULT_VCAP_SERVICES);
 
     @NotNull
-    private static FeatureMatcher<CfService, String> withName(String expected) {
-        return new FeatureMatcher<CfService, String>(equalTo(expected), "name", "name") {
+    private static FeatureMatcher<CloudFoundryServiceInstance, String> withName(String expected) {
+        return new FeatureMatcher<CloudFoundryServiceInstance, String>(equalTo(expected), "name", "name") {
             @Override
-            protected String featureValueOf(CfService cfService) {
+            protected String featureValueOf(CloudFoundryServiceInstance cfService) {
                 return cfService.getName();
             }
         };
@@ -48,66 +44,50 @@ public class CloudFoundryServicesAdapterTest {
 
     @Test
     public void getsAllServicesWithNullParameters() {
-        List<CfService> services = DEFAULT_ADAPTER.stream(null, null).collect(toList());
-        assertThat(services, allOf(
-                hasItem(withName("managed-find-me1")),
-                hasItem(withName("managed-find-me2")),
-                hasItem(withName("managed-other")),
-                hasItem(withName("managed-other1")),
-                hasItem(withName("managed-other2")),
-                hasItem(withName("ups-find-me1")),
-                hasItem(withName("ups-find-me2")),
-                hasItem(withName("ups-other"))
-        ));
+        List<CloudFoundryServiceInstance> services = DEFAULT_ADAPTER.stream(null, null).collect(toList());
+        assertThat(services, allOf(hasItem(withName("managed-find-me1")), hasItem(withName("managed-find-me2")),
+                                   hasItem(withName("managed-other")), hasItem(withName("managed-other1")),
+                                   hasItem(withName("managed-other2")), hasItem(withName("ups-find-me1")),
+                                   hasItem(withName("ups-find-me2")), hasItem(withName("ups-other"))));
     }
 
     @Test
     public void filtersBySingleLabel() {
-        List<CfService> services = DEFAULT_ADAPTER.stream(Collections.singletonList("managed-find-me-service"), emptyList()).collect(toList());
-        assertThat(services, allOf(
-                hasItem(withName("managed-find-me1")),
-                hasItem(withName("managed-find-me2")),
-                hasItem(withName("managed-other"))
-        ));
+        List<CloudFoundryServiceInstance> services =
+                DEFAULT_ADAPTER.stream(Collections.singletonList("managed-find-me-service"), emptyList())
+                               .collect(toList());
+        assertThat(services, allOf(hasItem(withName("managed-find-me1")), hasItem(withName("managed-find-me2")),
+                                   hasItem(withName("managed-other"))));
         assertThat(services, hasSize(3));
     }
 
     @Test
     public void priotizesByServiceLabel() {
-        List<CfService> services = DEFAULT_ADAPTER.stream(asList("user-provided", "managed-find-me-service"), emptyList()).collect(toList());
-        assertThat(services, contains(
-                withName("ups-find-me1"),
-                withName("ups-find-me2"),
-                withName("ups-other"),
-                withName("managed-find-me1"),
-                withName("managed-find-me2"),
-                withName("managed-other")
-        ));
+        List<CloudFoundryServiceInstance> services =
+                DEFAULT_ADAPTER.stream(asList("user-provided", "managed-find-me-service"), emptyList())
+                               .collect(toList());
+        assertThat(services, contains(withName("ups-find-me1"), withName("ups-find-me2"), withName("ups-other"),
+                                      withName("managed-find-me1"), withName("managed-find-me2"),
+                                      withName("managed-other")));
     }
 
     @Test
     public void filtersBySingleTag() {
-        List<CfService> services = DEFAULT_ADAPTER.stream(emptyList(), Collections.singletonList("Find Me!")).collect(toList());
-        assertThat(services, allOf(
-                hasItem(withName("managed-find-me1")),
-                hasItem(withName("managed-find-me2")),
-                hasItem(withName("managed-other1")),
-                hasItem(withName("ups-find-me1")),
-                hasItem(withName("ups-find-me2"))
-        ));
+        List<CloudFoundryServiceInstance> services =
+                DEFAULT_ADAPTER.stream(emptyList(), Collections.singletonList("Find Me!")).collect(toList());
+        assertThat(services, allOf(hasItem(withName("managed-find-me1")), hasItem(withName("managed-find-me2")),
+                                   hasItem(withName("managed-other1")), hasItem(withName("ups-find-me1")),
+                                   hasItem(withName("ups-find-me2"))));
         assertThat(services, hasSize(5));
     }
 
     @Test
     public void standardUseCase() {
-        List<CfService> services = DEFAULT_ADAPTER.stream(asList("user-provided", "managed-find-me-service"), Collections.singletonList("Find Me!")).collect(toList());
-        assertThat(services, contains(
-                withName("ups-find-me1"),
-                withName("ups-find-me2"),
-                withName("managed-find-me1"),
-                withName("managed-find-me2")
-        ));
+        List<CloudFoundryServiceInstance> services =
+                DEFAULT_ADAPTER.stream(asList("user-provided", "managed-find-me-service"),
+                                       Collections.singletonList("Find Me!")).collect(toList());
+        assertThat(services, contains(withName("ups-find-me1"), withName("ups-find-me2"), withName("managed-find-me1"),
+                                      withName("managed-find-me2")));
     }
-
 
 }

--- a/cf-java-logging-support-opentelemetry-agent-extension/src/test/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/binding/CloudLoggingBindingPropertiesSupplierTest.java
+++ b/cf-java-logging-support-opentelemetry-agent-extension/src/test/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/binding/CloudLoggingBindingPropertiesSupplierTest.java
@@ -1,6 +1,5 @@
 package com.sap.hcf.cf.logging.opentelemetry.agent.ext.binding;
 
-import io.pivotal.cfenv.core.CfService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -45,18 +44,10 @@ public class CloudLoggingBindingPropertiesSupplierTest {
     private CloudLoggingBindingPropertiesSupplier propertiesSupplier;
 
     private static void assertFileContent(String expected, String filename) throws IOException {
-        String contents = Files.readAllLines(Paths.get(filename))
-                .stream()
-                .collect(Collectors.joining("\n"));
+        String contents = Files.readAllLines(Paths.get(filename)).stream().collect(Collectors.joining("\n"));
         assertThat(contents, is(equalTo(expected)));
     }
-
-    private static CfService createCfService(Map<String, Object> properties, Map<String, Object> credentials) {
-        return new CfService(new HashMap<String, Object>(properties) {{
-            put("credentials", credentials);
-        }});
-    }
-
+    
     @Test
     public void emptyWithoutBindings() {
         when(servicesProvider.get()).thenReturn(Stream.empty());
@@ -66,8 +57,14 @@ public class CloudLoggingBindingPropertiesSupplierTest {
 
     @Test
     public void extractsBinding() throws Exception {
-        when(servicesProvider.get()).thenReturn(Stream.of(createCfService(BINDING, CREDENTIALS)));
-        CloudLoggingBindingPropertiesSupplier propertiesSupplier = new CloudLoggingBindingPropertiesSupplier(servicesProvider);
+        CloudFoundryCredentials credentials =
+                CloudFoundryCredentials.builder().add("ingest-otlp-endpoint", "test-endpoint")
+                                       .add("ingest-otlp-key", "test-client-key")
+                                       .add("ingest-otlp-cert", "test-client-cert").add("server-ca", "test-server-cert")
+                                       .build();
+        when(servicesProvider.get()).thenReturn(Stream.of(defaultInstance().credentials(credentials).build()));
+        CloudLoggingBindingPropertiesSupplier propertiesSupplier =
+                new CloudLoggingBindingPropertiesSupplier(servicesProvider);
 
         Map<String, String> properties = propertiesSupplier.get();
 
@@ -82,13 +79,19 @@ public class CloudLoggingBindingPropertiesSupplierTest {
         assertFileContent("test-server-cert", properties.get("otel.exporter.otlp.certificate"));
     }
 
+    private static CloudFoundryServiceInstance.Builder defaultInstance() {
+        return CloudFoundryServiceInstance.builder().name("test-name").label("user-provided").tag("Cloud Logging");
+    }
+
     @Test
     public void emptyWithoutEndpoint() {
-        HashMap<String, Object> credentials = new HashMap<String, Object>(CREDENTIALS) {{
-            remove("ingest-otlp-endpoint");
-        }};
-        when(servicesProvider.get()).thenReturn(Stream.of(createCfService(BINDING, credentials)));
-        CloudLoggingBindingPropertiesSupplier propertiesSupplier = new CloudLoggingBindingPropertiesSupplier(servicesProvider);
+        CloudFoundryCredentials credentials =
+                CloudFoundryCredentials.builder().add("ingest-otlp-key", "test-client-key")
+                                       .add("ingest-otlp-cert", "test-client-cert").add("server-ca", "test-server-cert")
+                                       .build();
+        when(servicesProvider.get()).thenReturn(Stream.of(defaultInstance().credentials(credentials).build()));
+        CloudLoggingBindingPropertiesSupplier propertiesSupplier =
+                new CloudLoggingBindingPropertiesSupplier(servicesProvider);
 
         Map<String, String> properties = propertiesSupplier.get();
 
@@ -97,11 +100,13 @@ public class CloudLoggingBindingPropertiesSupplierTest {
 
     @Test
     public void emptyWithoutClientCert() {
-        HashMap<String, Object> credentials = new HashMap<String, Object>(CREDENTIALS) {{
-            remove("ingest-otlp-cert");
-        }};
-        when(servicesProvider.get()).thenReturn(Stream.of(createCfService(BINDING, credentials)));
-        CloudLoggingBindingPropertiesSupplier propertiesSupplier = new CloudLoggingBindingPropertiesSupplier(servicesProvider);
+        CloudFoundryCredentials credentials =
+                CloudFoundryCredentials.builder().add("ingest-otlp-endpoint", "test-endpoint")
+                                       .add("ingest-otlp-key", "test-client-key").add("server-ca", "test-server-cert")
+                                       .build();
+        when(servicesProvider.get()).thenReturn(Stream.of(defaultInstance().credentials(credentials).build()));
+        CloudLoggingBindingPropertiesSupplier propertiesSupplier =
+                new CloudLoggingBindingPropertiesSupplier(servicesProvider);
 
         Map<String, String> properties = propertiesSupplier.get();
 
@@ -110,11 +115,13 @@ public class CloudLoggingBindingPropertiesSupplierTest {
 
     @Test
     public void emptyWithoutClientKey() {
-        HashMap<String, Object> credentials = new HashMap<String, Object>(CREDENTIALS) {{
-            remove("ingest-otlp-key");
-        }};
-        when(servicesProvider.get()).thenReturn(Stream.of(createCfService(BINDING, credentials)));
-        CloudLoggingBindingPropertiesSupplier propertiesSupplier = new CloudLoggingBindingPropertiesSupplier(servicesProvider);
+        CloudFoundryCredentials credentials =
+                CloudFoundryCredentials.builder().add("ingest-otlp-endpoint", "test-endpoint")
+                                       .add("ingest-otlp-cert", "test-client-cert").add("server-ca", "test-server-cert")
+                                       .build();
+        when(servicesProvider.get()).thenReturn(Stream.of(defaultInstance().credentials(credentials).build()));
+        CloudLoggingBindingPropertiesSupplier propertiesSupplier =
+                new CloudLoggingBindingPropertiesSupplier(servicesProvider);
 
         Map<String, String> properties = propertiesSupplier.get();
 
@@ -123,11 +130,13 @@ public class CloudLoggingBindingPropertiesSupplierTest {
 
     @Test
     public void emptyWithoutServerCert() {
-        HashMap<String, Object> credentials = new HashMap<String, Object>(CREDENTIALS) {{
-            remove("server-ca");
-        }};
-        when(servicesProvider.get()).thenReturn(Stream.of(createCfService(BINDING, credentials)));
-        CloudLoggingBindingPropertiesSupplier propertiesSupplier = new CloudLoggingBindingPropertiesSupplier(servicesProvider);
+        CloudFoundryCredentials credentials =
+                CloudFoundryCredentials.builder().add("ingest-otlp-endpoint", "test-endpoint")
+                                       .add("ingest-otlp-key", "test-client-key")
+                                       .add("ingest-otlp-cert", "test-client-cert").build();
+        when(servicesProvider.get()).thenReturn(Stream.of(defaultInstance().credentials(credentials).build()));
+        CloudLoggingBindingPropertiesSupplier propertiesSupplier =
+                new CloudLoggingBindingPropertiesSupplier(servicesProvider);
 
         Map<String, String> properties = propertiesSupplier.get();
 

--- a/cf-java-logging-support-opentelemetry-agent-extension/src/test/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/binding/CloudLoggingServicesProviderTest.java
+++ b/cf-java-logging-support-opentelemetry-agent-extension/src/test/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/binding/CloudLoggingServicesProviderTest.java
@@ -1,7 +1,6 @@
 package com.sap.hcf.cf.logging.opentelemetry.agent.ext.binding;
 
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
-import io.pivotal.cfenv.core.CfService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,7 +27,7 @@ public class CloudLoggingServicesProviderTest {
     private CloudFoundryServicesAdapter adapter;
 
     @Mock
-    private CfService mockService;
+    private CloudFoundryServiceInstance mockService;
 
     @Before
     public void setUp() throws Exception {
@@ -53,7 +52,8 @@ public class CloudLoggingServicesProviderTest {
         CloudLoggingServicesProvider provider = new CloudLoggingServicesProvider(config, adapter);
 
         assertThat(provider.get().collect(toList()), contains(mockService));
-        verify(adapter).stream(asList("unknown-label", "not-cloud-logging"), Collections.singletonList("Cloud Logging"));
+        verify(adapter).stream(asList("unknown-label", "not-cloud-logging"),
+                               Collections.singletonList("Cloud Logging"));
     }
 
     @Test
@@ -64,7 +64,8 @@ public class CloudLoggingServicesProviderTest {
         CloudLoggingServicesProvider provider = new CloudLoggingServicesProvider(emptyProperties, adapter);
 
         assertThat(provider.get().collect(toList()), contains(mockService));
-        verify(adapter).stream(asList("user-provided", "cloud-logging"), Collections.singletonList("NOT Cloud Logging"));
+        verify(adapter).stream(asList("user-provided", "cloud-logging"),
+                               Collections.singletonList("NOT Cloud Logging"));
     }
 
 }

--- a/cf-java-logging-support-opentelemetry-agent-extension/src/test/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/binding/DynatraceServicesProviderTest.java
+++ b/cf-java-logging-support-opentelemetry-agent-extension/src/test/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/binding/DynatraceServicesProviderTest.java
@@ -1,7 +1,6 @@
 package com.sap.hcf.cf.logging.opentelemetry.agent.ext.binding;
 
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
-import io.pivotal.cfenv.core.CfService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,7 +26,7 @@ public class DynatraceServicesProviderTest {
     private CloudFoundryServicesAdapter adapter;
 
     @Mock
-    private CfService mockService;
+    private CloudFoundryServiceInstance mockService;
 
     @Before
     public void setUp() throws Exception {

--- a/cf-java-logging-support-opentelemetry-agent-extension/src/test/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/exporter/CloudLoggingCredentialsTest.java
+++ b/cf-java-logging-support-opentelemetry-agent-extension/src/test/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/exporter/CloudLoggingCredentialsTest.java
@@ -1,12 +1,9 @@
 package com.sap.hcf.cf.logging.opentelemetry.agent.ext.exporter;
 
-import io.pivotal.cfenv.core.CfCredentials;
-import org.jetbrains.annotations.NotNull;
+import com.sap.hcf.cf.logging.opentelemetry.agent.ext.binding.CloudFoundryCredentials;
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -15,83 +12,78 @@ import static org.junit.Assert.assertTrue;
 
 public class CloudLoggingCredentialsTest {
 
-    private static final String VALID_CLIENT_CERT = "-----BEGIN CERTIFICATE-----\n" +
-            "Base-64-Encoded Certificate\n" +
-            "-----END CERTIFICATE-----\n";
+    private static final String VALID_CLIENT_CERT =
+            "-----BEGIN CERTIFICATE-----\n" + "Base-64-Encoded Certificate\n" + "-----END CERTIFICATE-----\n";
 
-    private static final String VALID_CLIENT_KEY = "-----BEGIN PRIVATE KEY-----\n" +
-            "Base-64-Encoded Private Key\n" +
-            "-----END PRIVATE KEY-----\n";
+    private static final String VALID_CLIENT_KEY =
+            "-----BEGIN PRIVATE KEY-----\n" + "Base-64-Encoded Private Key\n" + "-----END PRIVATE KEY-----\n";
 
-    private static final String VALID_SERVER_CERT = "-----BEGIN CERTIFICATE-----\n" +
-            "Base-64-Encoded Server Certificate\n" +
-            "-----END CERTIFICATE-----\n";
+    private static final String VALID_SERVER_CERT =
+            "-----BEGIN CERTIFICATE-----\n" + "Base-64-Encoded Server Certificate\n" + "-----END CERTIFICATE-----\n";
 
     private static final CloudLoggingCredentials.Parser PARSER = CloudLoggingCredentials.parser();
 
-    @NotNull
-    private static Map<String, Object> getValidCredData() {
-        Map<String, Object> credData = new HashMap<>();
-        credData.put("ingest-otlp-endpoint", "test-endpoint");
-        credData.put("ingest-otlp-cert", VALID_CLIENT_CERT);
-        credData.put("ingest-otlp-key", VALID_CLIENT_KEY);
-        credData.put("server-ca", VALID_SERVER_CERT);
-        return credData;
-    }
-
     @Test
     public void validCredentials() {
-        Map<String, Object> credData = getValidCredData();
-        CfCredentials cfCredentials = new CfCredentials(credData);
-        CloudLoggingCredentials credentials = PARSER.parse(cfCredentials);
+        CloudFoundryCredentials.Builder builder =
+                CloudFoundryCredentials.builder().add("ingest-otlp-endpoint", "test-endpoint")
+                                       .add("ingest-otlp-cert", VALID_CLIENT_CERT)
+                                       .add("ingest-otlp-key", VALID_CLIENT_KEY).add("server-ca", VALID_SERVER_CERT);
+        CloudLoggingCredentials credentials = PARSER.parse(builder.build());
         assertTrue("Credentials should be valid", credentials.validate());
     }
 
     @Test
     public void missingEndpoint() {
-        Map<String, Object> credData = getValidCredData();
-        credData.remove("ingest-otlp-endpoint");
-        CfCredentials cfCredentials = new CfCredentials(credData);
-        CloudLoggingCredentials credentials = PARSER.parse(cfCredentials);
+        CloudFoundryCredentials.Builder builder =
+                CloudFoundryCredentials.builder().add("ingest-otlp-cert", VALID_CLIENT_CERT)
+                                       .add("ingest-otlp-key", VALID_CLIENT_KEY).add("server-ca", VALID_SERVER_CERT);
+        CloudLoggingCredentials credentials = PARSER.parse(builder.build());
         assertFalse("Credentials should be invalid", credentials.validate());
     }
 
     @Test
     public void missingClientKey() {
-        Map<String, Object> credData = getValidCredData();
-        credData.remove("ingest-otlp-key");
-        CfCredentials cfCredentials = new CfCredentials(credData);
-        CloudLoggingCredentials credentials = PARSER.parse(cfCredentials);
+        CloudFoundryCredentials.Builder builder =
+                CloudFoundryCredentials.builder().add("ingest-otlp-endpoint", "test-endpoint")
+                                       .add("ingest-otlp-cert", VALID_CLIENT_CERT).add("server-ca", VALID_SERVER_CERT);
+        CloudLoggingCredentials credentials = PARSER.parse(builder.build());
         assertFalse("Credentials should be invalid", credentials.validate());
     }
 
     @Test
     public void missingClientCert() {
-        Map<String, Object> credData = getValidCredData();
-        credData.remove("ingest-otlp-cert");
-        CfCredentials cfCredentials = new CfCredentials(credData);
-        CloudLoggingCredentials credentials = PARSER.parse(cfCredentials);
+        CloudFoundryCredentials.Builder builder =
+                CloudFoundryCredentials.builder().add("ingest-otlp-endpoint", "test-endpoint")
+                                       .add("ingest-otlp-key", VALID_CLIENT_KEY).add("server-ca", VALID_SERVER_CERT);
+        CloudLoggingCredentials credentials = PARSER.parse(builder.build());
         assertFalse("Credentials should be invalid", credentials.validate());
     }
 
     @Test
     public void missingServerCert() {
-        Map<String, Object> credData = getValidCredData();
-        credData.remove("server-ca");
-        CfCredentials cfCredentials = new CfCredentials(credData);
-        CloudLoggingCredentials credentials = PARSER.parse(cfCredentials);
+        CloudFoundryCredentials.Builder builder =
+                CloudFoundryCredentials.builder().add("ingest-otlp-endpoint", "test-endpoint")
+                                       .add("ingest-otlp-cert", VALID_CLIENT_CERT)
+                                       .add("ingest-otlp-key", VALID_CLIENT_KEY);
+        CloudLoggingCredentials credentials = PARSER.parse(builder.build());
         assertFalse("Credentials should be invalid", credentials.validate());
     }
 
     @Test
     public void parsesCorrectly() {
-        Map<String, Object> credData = getValidCredData();
-        CfCredentials cfCredentials = new CfCredentials(credData);
-        CloudLoggingCredentials credentials = PARSER.parse(cfCredentials);
+        CloudFoundryCredentials.Builder builder =
+                CloudFoundryCredentials.builder().add("ingest-otlp-endpoint", "test-endpoint")
+                                       .add("ingest-otlp-cert", VALID_CLIENT_CERT)
+                                       .add("ingest-otlp-key", VALID_CLIENT_KEY).add("server-ca", VALID_SERVER_CERT);
+        CloudLoggingCredentials credentials = PARSER.parse(builder.build());
         assertThat(credentials.getEndpoint(), equalTo("https://test-endpoint"));
-        assertThat(new String(credentials.getClientCert(), StandardCharsets.UTF_8), equalTo("-----BEGIN CERTIFICATE-----\nBase-64-Encoded Certificate\n-----END CERTIFICATE-----"));
-        assertThat(new String(credentials.getClientKey(), StandardCharsets.UTF_8), equalTo("-----BEGIN PRIVATE KEY-----\nBase-64-Encoded Private Key\n-----END PRIVATE KEY-----"));
-        assertThat(new String(credentials.getServerCert(), StandardCharsets.UTF_8), equalTo("-----BEGIN CERTIFICATE-----\nBase-64-Encoded Server Certificate\n-----END CERTIFICATE-----"));
+        assertThat(new String(credentials.getClientCert(), StandardCharsets.UTF_8),
+                   equalTo("-----BEGIN CERTIFICATE-----\nBase-64-Encoded Certificate\n-----END CERTIFICATE-----"));
+        assertThat(new String(credentials.getClientKey(), StandardCharsets.UTF_8),
+                   equalTo("-----BEGIN PRIVATE KEY-----\nBase-64-Encoded Private Key\n-----END PRIVATE KEY-----"));
+        assertThat(new String(credentials.getServerCert(), StandardCharsets.UTF_8),
+                   equalTo("-----BEGIN CERTIFICATE-----\nBase-64-Encoded Server Certificate\n-----END CERTIFICATE-----"));
     }
 
 }

--- a/cf-java-logging-support-opentelemetry-agent-extension/src/test/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/exporter/CloudLoggingMetricsExporterProviderTest.java
+++ b/cf-java-logging-support-opentelemetry-agent-extension/src/test/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/exporter/CloudLoggingMetricsExporterProviderTest.java
@@ -1,9 +1,9 @@
 package com.sap.hcf.cf.logging.opentelemetry.agent.ext.exporter;
 
+import com.sap.hcf.cf.logging.opentelemetry.agent.ext.binding.CloudFoundryServiceInstance;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
-import io.pivotal.cfenv.core.CfService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -14,7 +14,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.ServiceLoader;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -31,7 +30,7 @@ import static org.mockito.Mockito.when;
 public class CloudLoggingMetricsExporterProviderTest {
 
     @Mock
-    private Function<ConfigProperties, Stream<CfService>> servicesProvider;
+    private Function<ConfigProperties, Stream<CloudFoundryServiceInstance>> servicesProvider;
 
     @Mock
     private CloudLoggingCredentials.Parser credentialParser;
@@ -55,10 +54,11 @@ public class CloudLoggingMetricsExporterProviderTest {
 
     @Test
     public void canLoadViaSPI() {
-        ServiceLoader<ConfigurableMetricExporterProvider> loader = ServiceLoader.load(ConfigurableMetricExporterProvider.class);
+        ServiceLoader<ConfigurableMetricExporterProvider> loader =
+                ServiceLoader.load(ConfigurableMetricExporterProvider.class);
         Stream<ConfigurableMetricExporterProvider> providers = StreamSupport.stream(loader.spliterator(), false);
         assertTrue(CloudLoggingMetricsExporterProvider.class.getName() + " not loaded via SPI",
-                providers.anyMatch(p -> p instanceof CloudLoggingMetricsExporterProvider));
+                   providers.anyMatch(p -> p instanceof CloudLoggingMetricsExporterProvider));
     }
 
     @Test
@@ -71,8 +71,7 @@ public class CloudLoggingMetricsExporterProviderTest {
 
     @Test
     public void registersNoopExporterWithInvalidBindings() {
-        CfService genericCfService = new CfService(Collections.emptyMap());
-        when(servicesProvider.apply(config)).thenReturn(Stream.of(genericCfService));
+        when(servicesProvider.apply(config)).thenReturn(Stream.of(CloudFoundryServiceInstance.builder().build()));
         CloudLoggingCredentials cloudLoggingCredentials = mock(CloudLoggingCredentials.class);
         when(credentialParser.parse(any())).thenReturn(cloudLoggingCredentials);
         when(cloudLoggingCredentials.validate()).thenReturn(false);
@@ -83,8 +82,8 @@ public class CloudLoggingMetricsExporterProviderTest {
 
     @Test
     public void registersExportersWithValidBindings() throws IOException {
-        CfService genericCfService = new CfService(Collections.emptyMap());
-        CfService cloudLoggingService = new CfService(Collections.emptyMap());
+        CloudFoundryServiceInstance genericCfService = CloudFoundryServiceInstance.builder().build();
+        CloudFoundryServiceInstance cloudLoggingService = CloudFoundryServiceInstance.builder().build();
         when(servicesProvider.apply(config)).thenReturn(Stream.of(genericCfService, cloudLoggingService));
         CloudLoggingCredentials invalidCredentials = mock(CloudLoggingCredentials.class);
         when(invalidCredentials.validate()).thenReturn(false);
@@ -97,7 +96,8 @@ public class CloudLoggingMetricsExporterProviderTest {
         when(credentialParser.parse(any())).thenReturn(invalidCredentials).thenReturn(validCredentials);
         MetricExporter exporter = exporterProvider.createExporter(config);
         assertThat(exporter, is(notNullValue()));
-        assertThat(exporter.toString(), both(containsString("OtlpGrpcMetricExporter")).and(containsString("https://otlp-example.sap")));
+        assertThat(exporter.toString(),
+                   both(containsString("OtlpGrpcMetricExporter")).and(containsString("https://otlp-example.sap")));
     }
 
 }

--- a/cf-java-logging-support-opentelemetry-agent-extension/src/test/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/exporter/CloudLoggingSpanExporterProviderTest.java
+++ b/cf-java-logging-support-opentelemetry-agent-extension/src/test/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/exporter/CloudLoggingSpanExporterProviderTest.java
@@ -1,9 +1,9 @@
 package com.sap.hcf.cf.logging.opentelemetry.agent.ext.exporter;
 
+import com.sap.hcf.cf.logging.opentelemetry.agent.ext.binding.CloudFoundryServiceInstance;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
-import io.pivotal.cfenv.core.CfService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -14,7 +14,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.ServiceLoader;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -31,7 +30,7 @@ import static org.mockito.Mockito.when;
 public class CloudLoggingSpanExporterProviderTest {
 
     @Mock
-    private Function<ConfigProperties, Stream<CfService>> servicesProvider;
+    private Function<ConfigProperties, Stream<CloudFoundryServiceInstance>> servicesProvider;
 
     @Mock
     private CloudLoggingCredentials.Parser credentialParser;
@@ -55,10 +54,11 @@ public class CloudLoggingSpanExporterProviderTest {
 
     @Test
     public void canLoadViaSPI() {
-        ServiceLoader<ConfigurableSpanExporterProvider> loader = ServiceLoader.load(ConfigurableSpanExporterProvider.class);
+        ServiceLoader<ConfigurableSpanExporterProvider> loader =
+                ServiceLoader.load(ConfigurableSpanExporterProvider.class);
         Stream<ConfigurableSpanExporterProvider> providers = StreamSupport.stream(loader.spliterator(), false);
         assertTrue(CloudLoggingSpanExporterProvider.class.getName() + " not loaded via SPI",
-                providers.anyMatch(p -> p instanceof CloudLoggingSpanExporterProvider));
+                   providers.anyMatch(p -> p instanceof CloudLoggingSpanExporterProvider));
     }
 
     @Test
@@ -71,8 +71,7 @@ public class CloudLoggingSpanExporterProviderTest {
 
     @Test
     public void registersNoopExporterWithInvalidBindings() {
-        CfService genericCfService = new CfService(Collections.emptyMap());
-        when(servicesProvider.apply(config)).thenReturn(Stream.of(genericCfService));
+        when(servicesProvider.apply(config)).thenReturn(Stream.of(CloudFoundryServiceInstance.builder().build()));
         CloudLoggingCredentials cloudLoggingCredentials = mock(CloudLoggingCredentials.class);
         when(credentialParser.parse(any())).thenReturn(cloudLoggingCredentials);
         when(cloudLoggingCredentials.validate()).thenReturn(false);
@@ -83,8 +82,8 @@ public class CloudLoggingSpanExporterProviderTest {
 
     @Test
     public void registersExportersWithValidBindings() throws IOException {
-        CfService genericCfService = new CfService(Collections.emptyMap());
-        CfService cloudLoggingService = new CfService(Collections.emptyMap());
+        CloudFoundryServiceInstance genericCfService = CloudFoundryServiceInstance.builder().build();
+        CloudFoundryServiceInstance cloudLoggingService = CloudFoundryServiceInstance.builder().build();
         when(servicesProvider.apply(config)).thenReturn(Stream.of(genericCfService, cloudLoggingService));
         CloudLoggingCredentials invalidCredentials = mock(CloudLoggingCredentials.class);
         when(invalidCredentials.validate()).thenReturn(false);
@@ -97,7 +96,8 @@ public class CloudLoggingSpanExporterProviderTest {
         when(credentialParser.parse(any())).thenReturn(invalidCredentials).thenReturn(validCredentials);
         SpanExporter exporter = exporterProvider.createExporter(config);
         assertThat(exporter, is(notNullValue()));
-        assertThat(exporter.toString(), both(containsString("OtlpGrpcSpanExporter")).and(containsString("https://otlp-example.sap")));
+        assertThat(exporter.toString(),
+                   both(containsString("OtlpGrpcSpanExporter")).and(containsString("https://otlp-example.sap")));
     }
 
 }

--- a/cf-java-logging-support-opentelemetry-agent-extension/src/test/resources/com/sap/hcf/cf/logging/opentelemetry/agent/ext/vcap_application.json
+++ b/cf-java-logging-support-opentelemetry-agent-extension/src/test/resources/com/sap/hcf/cf/logging/opentelemetry/agent/ext/vcap_application.json
@@ -1,0 +1,19 @@
+{
+  "application_id": "test-app-id",
+  "application_name": "test-application",
+  "application_uris": [
+    "test-application.example.com"
+  ],
+  "cf_api": "https://api.cf.example.com",
+  "limits": {
+    "fds": 256
+  },
+  "instance_index": 42,
+  "organization_id": "test-org-id",
+  "organization_name": "test-org",
+  "process_id": "test-process-id",
+  "process_type": "test-process-type",
+  "space_id": "test-space-id",
+  "space_name": "test-space",
+  "users": null
+}


### PR DESCRIPTION
addresses #205 

To avoid version conflicts, this dependency was removed. The logic was rewritten to only use the JsonParser provided by Jackson from the OTel Java Agent.

The resource provider is now built on the community version of the CF resources and can even emit the attributes following the official semantic conventions by configuration.