### PR TITLE
Add StructuredLogFormatter wrapper for JsonEncoder (logback)

### DIFF
--- a/cf-java-logging-support-logback/pom.xml
+++ b/cf-java-logging-support-logback/pom.xml
@@ -26,6 +26,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot</artifactId>
+            <version>${springboot.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.sap.hcp.cf.logging</groupId>
             <artifactId>cf-java-logging-support-core</artifactId>
             <type>test-jar</type>

--- a/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/boot/CloudFoundryStructuredLogFormatter.java
+++ b/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/boot/CloudFoundryStructuredLogFormatter.java
@@ -1,0 +1,39 @@
+package com.sap.hcp.cf.logback.boot;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import com.sap.hcp.cf.logback.encoder.JsonEncoder;
+import org.springframework.boot.logging.structured.StructuredLogFormatter;
+
+/**
+ * A Logback events formatter for structured logging in SpringBoot
+ * configuration, suited
+ * for Cloud Foundry applications. This class can be used as a value for
+ * {@code logging.structured.format.console}
+ * or @{code logging.structured.format.file} in a SpringBoot applications.
+ * <p>
+ * This is a simple wrapper around the {@code JsonEncoder} created for Logback.
+ * This formatter does not accept any configuration parameters and uses the default
+ * settings coming with JsonEncoder. The JSON output will contain the same fields 
+ * as produced with {@code JsonEncoder}, but you don't have to use logback.xml 
+ * (or logback-spring.xml) to use it.
+  * <p>
+ * Example usage with SpringBoot ({@code application.properties}):
+ * 
+ * <pre>
+ * logging.structured.format.console = com.sap.hcp.cf.logback.boot.CloudFoundryStructuredLogFormatter
+ * </pre>
+ */
+public class CloudFoundryStructuredLogFormatter implements StructuredLogFormatter<ILoggingEvent> {
+
+    private final JsonEncoder jsonEncoder;
+
+    public CloudFoundryStructuredLogFormatter() {
+        this.jsonEncoder = JsonEncoder.createStarted();
+    }
+
+    @Override
+    public String format(ILoggingEvent event) {
+        return jsonEncoder.getJson(event);
+    }
+
+}

--- a/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/encoder/JsonEncoder.java
+++ b/cf-java-logging-support-logback/src/main/java/com/sap/hcp/cf/logback/encoder/JsonEncoder.java
@@ -21,7 +21,6 @@ import com.sap.hcp.cf.logging.common.converter.LineWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.jr.ob.JSON;
 import com.fasterxml.jackson.jr.ob.JSON.Builder;
@@ -76,6 +75,19 @@ public class JsonEncoder extends EncoderBase<ILoggingEvent> {
         logbackContextFieldSuppliers.add(new BaseFieldSupplier());
         logbackContextFieldSuppliers.add(new EventContextFieldSupplier());
         logbackContextFieldSuppliers.add(new RequestRecordFieldSupplier());
+    }
+
+    /**
+     * Creates a new encoder instance in the {@code started} state, with default settings. 
+     * This means that the encoder is ready to encode log events once this method returns.
+     * 
+     * @return a new {@link JsonEncoder} instance in the started state
+     */
+    public static JsonEncoder createStarted() {
+        JsonEncoder encoder = new JsonEncoder();
+        encoder.start();
+
+        return encoder;
     }
 
     /**
@@ -286,7 +298,11 @@ public class JsonEncoder extends EncoderBase<ILoggingEvent> {
         return getJson(event).getBytes(charset);
     }
 
-    private String getJson(ILoggingEvent event) {
+    public String getJson(ILoggingEvent event) {
+        if(!isStarted()) {
+            throw new IllegalStateException("Encoder is not started. Please call start() before encoding.");
+        }
+
         try (StringWriter writer = new StringWriter()) {
             ObjectComposer<JSONComposer<OutputStream>> oc = json.composeTo(writer).startObject();
             addMarkers(oc, event);

--- a/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logback/boot/CloudFoundryStructuredLogFormatterTest.java
+++ b/cf-java-logging-support-logback/src/test/java/com/sap/hcp/cf/logback/boot/CloudFoundryStructuredLogFormatterTest.java
@@ -1,0 +1,32 @@
+package com.sap.hcp.cf.logback.boot;
+
+import static org.junit.Assert.assertTrue;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import org.junit.Test;
+
+public class CloudFoundryStructuredLogFormatterTest {
+    
+    CloudFoundryStructuredLogFormatter underTest = new CloudFoundryStructuredLogFormatter();
+    
+    @Test
+    public void testFormat() throws Exception {
+        LoggingEvent event = new LoggingEvent();
+        event.setLevel(Level.DEBUG);
+        event.setLoggerName("my-logger");
+        event.setMessage("This is some very important log message");
+        event.setThreadName("thread-1");
+
+        String result = underTest.format(event);
+
+        assertTrue(result.startsWith("{"));
+        assertTrue(result.endsWith("}\n"));
+        assertTrue(result.contains("\"level\":\"DEBUG\""));
+        assertTrue(result.contains("\"logger\":\"my-logger\""));
+        assertTrue(result.contains("\"msg\":\"This is some very important log message\""));
+        assertTrue(result.contains("\"thread\":\"thread-1\""));
+
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,7 @@
         <java-jwt.version>4.4.0</java-jwt.version>
         <jackson-databind.version>2.18.2</jackson-databind.version>
         <httpclient.version>4.5.14</httpclient.version>
+        <springboot.version>3.4.5</springboot.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Hi, I wanted to be able to use the JsonEncoder for Logback with SpringBoot (3.4+), but not have to create a `logback.xml`.

So I created this simple wrapper. Then I'm able to use the encoder as a formatter for structured logging with just a regular `application.properties` / `.yaml`, like this:

```
# application.yaml
logging:
  structured:
    format:
      console: com.sap.hcp.cf.logback.boot.CloudFoundryStructuredLogFormatter
      #console: ecs
  level:
    root: INFO
    com.sap.cloud.sdk: INFO
    com.sap.cloud.security: DEBUG
```

Let me know what you think. In our application, I've created a similar wrapper, but since `JsonEncoder` does not expose the `getJson(event)` method, it's a little bit cumbersome -- I had to use reflection. I didn't want to use the public `encode(event)` because I'd need to decode it right back using UTF-8 into a `String` instance, every time.

Alternatively, if you could expose the `JsonEncoder.getJson(event)` method (or a new one, returning JSON as String), that'd help us a lot as well. I know this commit drags with itself a dependency on SpringBoot, which might not be ideal.

 