### PR TITLE
Upgrade OTel SDK Dependency

### DIFF
--- a/cf-java-logging-support-opentelemetry-agent-extension/pom.xml
+++ b/cf-java-logging-support-opentelemetry-agent-extension/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <opentelemetry.sdk.version>1.50.0</opentelemetry.sdk.version>
+        <opentelemetry.sdk.version>1.52.0</opentelemetry.sdk.version>
     </properties>
 
     <dependencyManagement>
@@ -63,6 +63,12 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <version>${jackson-jr.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>4.9.3</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>uk.org.webcompere</groupId>

--- a/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/binding/CloudLoggingBindingPropertiesSupplier.java
+++ b/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/binding/CloudLoggingBindingPropertiesSupplier.java
@@ -36,7 +36,7 @@ public class CloudLoggingBindingPropertiesSupplier implements Supplier<Map<Strin
         defaults.put("com.sap.otel.extension.cloud-logging.label", "cloud-logging");
         defaults.put("com.sap.otel.extension.cloud-logging.tag", "Cloud Logging");
         defaults.put("otel.javaagent.extension.sap.cf.binding.user-provided.label", "user-provided");
-        return DefaultConfigProperties.create(defaults);
+        return DefaultConfigProperties.createFromMap(defaults);
     }
 
     private static boolean isBlank(String text) {

--- a/cf-java-logging-support-opentelemetry-agent-extension/src/test/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/attributes/CloudFoundryResourceCustomizerTest.java
+++ b/cf-java-logging-support-opentelemetry-agent-extension/src/test/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/attributes/CloudFoundryResourceCustomizerTest.java
@@ -24,7 +24,7 @@ public class CloudFoundryResourceCustomizerTest {
     public void emptyResourceWhenNotInCf() {
         CloudFoundryResourceCustomizer customizer = new CloudFoundryResourceCustomizer();
         Resource resource =
-                customizer.apply(Resource.builder().build(), DefaultConfigProperties.create(new HashMap<>()));
+                customizer.apply(Resource.builder().build(), DefaultConfigProperties.createFromMap(new HashMap<>()));
         assertTrue(resource.getAttributes().isEmpty());
     }
 
@@ -35,7 +35,8 @@ public class CloudFoundryResourceCustomizerTest {
         properties.put("otel.javaagent.extension.sap.cf.resource.enabled", "false");
 
         CloudFoundryResourceCustomizer customizer = new CloudFoundryResourceCustomizer();
-        Resource resource = customizer.apply(Resource.builder().build(), DefaultConfigProperties.create(properties));
+        Resource resource =
+                customizer.apply(Resource.builder().build(), DefaultConfigProperties.createFromMap(properties));
         assertTrue(resource.getAttributes().isEmpty());
     }
 
@@ -43,7 +44,7 @@ public class CloudFoundryResourceCustomizerTest {
     public void fillsResourceFromVcapApplication() {
         CloudFoundryResourceCustomizer customizer = new CloudFoundryResourceCustomizer();
         Resource resource =
-                customizer.apply(DEFAULT_CF_RESOURCE, DefaultConfigProperties.create(Collections.emptyMap()));
+                customizer.apply(DEFAULT_CF_RESOURCE, DefaultConfigProperties.createFromMap(Collections.emptyMap()));
         assertEquals("test-application", resource.getAttribute(AttributeKey.stringKey("service.name")));
         assertEquals("test-application", resource.getAttribute(AttributeKey.stringKey("sap.cf.app_name")));
         assertEquals("test-app-id", resource.getAttribute(AttributeKey.stringKey("sap.cf.app_id")));
@@ -62,7 +63,7 @@ public class CloudFoundryResourceCustomizerTest {
         HashMap<String, String> config = new HashMap<String, String>() {{
             put("otel.javaagent.extension.sap.cf.resource.format", "opentelemetry");
         }};
-        Resource resource = customizer.apply(DEFAULT_CF_RESOURCE, DefaultConfigProperties.create(config));
+        Resource resource = customizer.apply(DEFAULT_CF_RESOURCE, DefaultConfigProperties.createFromMap(config));
 
         assertEquals(DEFAULT_CF_RESOURCE, resource);
     }


### PR DESCRIPTION
Slight adaptations of the code to the changed API. The additional test dependency is required as the original dependency is no longer transitive but "provided".