### PR TITLE
Add dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,6 @@ updates:
     schedule:
       interval: "daily"
     target-branch: "release-4"
+    labels:
+      - "dependencies"
+      - "release-4"


### PR DESCRIPTION
Let dependabot help keeping the project dependencies up to date. Checks should be performed against the main and release-4 branch.