### PR TITLE
Fix OTel CF resource provider

### DIFF
--- a/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/CloudFoundryResourceProvider.java
+++ b/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/CloudFoundryResourceProvider.java
@@ -1,11 +1,10 @@
 package com.sap.hcf.cf.logging.opentelemetry.agent.ext;
 
 import com.sap.hcf.cf.logging.opentelemetry.agent.ext.attributes.CloudFoundryResourceCustomizer;
+import io.opentelemetry.contrib.cloudfoundry.resources.CloudFoundryResource;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ResourceProvider;
 import io.opentelemetry.sdk.resources.Resource;
-
-import java.util.ServiceLoader;
 
 public class CloudFoundryResourceProvider implements ResourceProvider {
 
@@ -13,25 +12,8 @@ public class CloudFoundryResourceProvider implements ResourceProvider {
 
     @Override
     public Resource createResource(ConfigProperties configProperties) {
-        ResourceProvider delegate = getDelegate();
-        return delegate == null
-                ? Resource.empty()
-                : customizer.apply(delegate.createResource(configProperties), configProperties);
+        Resource original = CloudFoundryResource.get();
+        return customizer.apply(original, configProperties);
     }
 
-    private ResourceProvider getDelegate() {
-        return DelegateHolder.INSTANCE;
-    }
-
-    private static class DelegateHolder {
-        static final ResourceProvider INSTANCE = loadCloudFoundryResourceProvider();
-
-        private static ResourceProvider loadCloudFoundryResourceProvider() {
-            ServiceLoader<ResourceProvider> loader = ServiceLoader.load(ResourceProvider.class);
-            return loader.stream().map(ServiceLoader.Provider::get)
-                         .filter(p -> p instanceof io.opentelemetry.contrib.cloudfoundry.resources.CloudFoundryResourceProvider)
-                         .findAny().orElse(null);
-        }
-
-    }
 }


### PR DESCRIPTION
Uses the simpler implementation from release-3.
The service loader does not load the required provider this early in the lifecycle. The old implementation is proven in existing versions of the extension. Testing showed it to be effective with the new release.

c.f. https://github.com/SAP/cf-java-logging-support/blob/79ea43599e01c5225d71f1c80b614dc340d41061/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/CloudFoundryResourceProvider.java