### PR TITLE
Deprecate CaaS support

### DIFF
--- a/cf-java-logging-support-opentelemetry-agent-extension/README.md
+++ b/cf-java-logging-support-opentelemetry-agent-extension/README.md
@@ -5,7 +5,7 @@ The extension scans the service bindings of an application for SAP Collector as 
 If such a binding is found, the OpenTelemetry Java Agent is configured to ship observability data to those services.
 Thus, this extension provides a convenient auto-instrumentation for Java applications running on SAP BTP.
 
-> Note: CaaS currently is an SAP internal only service.
+> Note: CaaS is an SAP internal only service. The service bindings supported by this extension (v1) are no longer created. CaaS support is deprecated as of version 4.3.0 and will be removed in a future release.
 
 The extension provides the following main features:
 
@@ -95,7 +95,7 @@ The extension itself can be configured by specifying the following system proper
 
 | Property                                   | Description                                                                                                                                     | Default Value   |
 |--------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|
-| `sap.caas.cf.binding.label.value`          | The label of the managed CaaS service binding to bind to.                                                                                       | `caas-service`  |
+| `sap.caas.cf.binding.label.value`          | **Deprecated since 4.3.0.** The label of the managed CaaS service binding to bind to.                                                                                       | `caas-service`  |
 | `sap.cloud-logging.cf.binding.label.value` | The label of the managed service binding to bind to.                                                                                            | `cloud-logging` |
 | `sap.cloud-logging.cf.binding.tag.value`   | The tag of any service binding (managed or user-provided) to bind to.                                                                           | `Cloud Logging` |
 | `sap.dynatrace.cf.binding.label.value`     | The label of the managed service binding to bind to.                                                                                            | `dynatrace`     |

--- a/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/binding/CaasBindingPropertiesSupplier.java
+++ b/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/binding/CaasBindingPropertiesSupplier.java
@@ -14,6 +14,12 @@ import java.util.logging.Logger;
 
 import static java.util.Collections.emptyMap;
 
+/**
+ * Supplies OTel configuration properties derived from a CaaS (Collector as a Service) service binding.
+ *
+ * @deprecated CaaS is an SAP internal only service. The service bindings supported by this extension (v1) are no longer created. Will be removed in a future release.
+ */
+@Deprecated(since = "4.3.0", forRemoval = true)
 public class CaasBindingPropertiesSupplier implements Supplier<Map<String, String>> {
 
     private static final String CAAS_CLIENT_KEY = "tls.key";

--- a/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/binding/CaasServiceProvider.java
+++ b/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/binding/CaasServiceProvider.java
@@ -6,6 +6,12 @@ import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import java.util.Collections;
 import java.util.function.Supplier;
 
+/**
+ * Provides the CaaS (Collector as a Service) service binding.
+ *
+ * @deprecated CaaS is an SAP internal only service. The service bindings supported by this extension (v1) are no longer created. Will be removed in a future release.
+ */
+@Deprecated(since = "4.3.0", forRemoval = true)
 public class CaasServiceProvider implements Supplier<CloudFoundryServiceInstance> {
 
     private final CloudFoundryServiceInstance service;

--- a/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/config/ExtensionConfigurations.java
+++ b/cf-java-logging-support-opentelemetry-agent-extension/src/main/java/com/sap/hcf/cf/logging/opentelemetry/agent/ext/config/ExtensionConfigurations.java
@@ -382,12 +382,20 @@ public interface ExtensionConfigurations {
     interface RUNTIME {
         interface CLOUD_FOUNDRY {
             interface SERVICE {
+                /**
+                 * @deprecated CaaS is an SAP internal only service. The service bindings supported by this extension (v1) are no longer created.
+                 *             Will be removed in a future release.
+                 */
+                @Deprecated(since = "4.3.0", forRemoval = true)
                 interface CAAS {
                     /**
                      * <p>Parses {@code sap.caas.cf.binding.label.value}.</p>
                      * <p>The label value used to identify managed CaaS service bindings. Default is
                      * {@code "caas-service"}.</p>
+                     *
+                     * @deprecated CaaS is an SAP internal only service. The service bindings supported by this extension (v1) are no longer created.
                      */
+                    @Deprecated(since = "4.3.0", forRemoval = true)
                     ConfigProperty<String> LABEL =
                             stringValued("sap.caas.cf.binding.label.value").withDefaultValue("caas-service").build();
                 }


### PR DESCRIPTION
The support for the SAP internal service CaaS was only for v1 of its service bindings. The service has now switched to a different format (v2) and is providing a separate agent extension. Therefore, the support in this extension is deprecated for removal.